### PR TITLE
Add new FileSpec Test cases

### DIFF
--- a/tests/yaml/S_Bash_0543.yml
+++ b/tests/yaml/S_Bash_0543.yml
@@ -1,0 +1,23 @@
+resources:
+  - name: S_Bash_0543_FileSpec
+    type: FileSpec
+    configuration:
+      sourceArtifactory: s_artifactory
+      pattern: "*/s_foo*"
+      limit: 1
+      sortBy:
+        - created
+      target: "/testing/"
+pipelines:
+  - name: pipelines_S_Bash_0543
+    steps:
+      - name: S_Bash_0543
+        type: Bash
+        configuration:
+          inputResources:
+            - name: S_Bash_0543_FileSpec
+        execution:
+          onExecute:
+            - echo "executing step"
+            - if [ -f "/testing/s_foo" ]; then echo "found the file"; fi
+            - if [ ! -f "/testing/s_foo" ]; then echo "error finding the file"; exit 1; fi

--- a/tests/yaml/S_Bash_0544.yml
+++ b/tests/yaml/S_Bash_0544.yml
@@ -6,7 +6,7 @@ resources:
       pattern: "*/s_foo*"
       limit: 1
       excludePatterns:
-        - "/testing"
+        - "*/pipeInfo.json"
       target: "/testing/"
 pipelines:
   - name: pipelines_S_Bash_0544

--- a/tests/yaml/S_Bash_0544.yml
+++ b/tests/yaml/S_Bash_0544.yml
@@ -1,0 +1,23 @@
+resources:
+  - name: S_Bash_0544_FileSpec
+    type: FileSpec
+    configuration:
+      sourceArtifactory: s_artifactory
+      pattern: "*/s_foo*"
+      limit: 1
+      excludePatterns:
+        - "/testing"
+      target: "/testing/"
+pipelines:
+  - name: pipelines_S_Bash_0544
+    steps:
+      - name: S_Bash_0544
+        type: Bash
+        configuration:
+          inputResources:
+            - name: S_Bash_0544_FileSpec
+        execution:
+          onExecute:
+            - echo "executing step"
+            - if [ -f "/testing/s_foo" ]; then echo "found the file"; fi
+            - if [ ! -f "/testing/s_foo" ]; then echo "error finding the file"; exit 1; fi

--- a/tests/yaml/S_Bash_0545.yml
+++ b/tests/yaml/S_Bash_0545.yml
@@ -6,7 +6,7 @@ resources:
       pattern: "*/s_foo*"
       limit: 1
       exclusions:
-        - "/testing"
+        - "*/pipeInfo.json"
       target: "/testing/"
 pipelines:
   - name: pipelines_S_Bash_0545

--- a/tests/yaml/S_Bash_0545.yml
+++ b/tests/yaml/S_Bash_0545.yml
@@ -1,0 +1,23 @@
+resources:
+  - name: S_Bash_0545_FileSpec
+    type: FileSpec
+    configuration:
+      sourceArtifactory: s_artifactory
+      pattern: "*/s_foo*"
+      limit: 1
+      exclusions:
+        - "/testing"
+      target: "/testing/"
+pipelines:
+  - name: pipelines_S_Bash_0545
+    steps:
+      - name: S_Bash_0545
+        type: Bash
+        configuration:
+          inputResources:
+            - name: S_Bash_0545_FileSpec
+        execution:
+          onExecute:
+            - echo "executing step"
+            - if [ -f "/testing/s_foo" ]; then echo "found the file"; fi
+            - if [ ! -f "/testing/s_foo" ]; then echo "error finding the file"; exit 1; fi


### PR DESCRIPTION
https://www.jfrog.com/jira/browse/PIPE-4410
- S-Bash-0543. User uses filespec with pattern, valid sortBy to ' +
      'download input resources for a step in bash and triggers the run ' +
      'and sees the run is successful.
- S-Bash-0544. User uses filespec with pattern, valid excludePatterns to ' +
      'download input resources for a step in bash and triggers the run ' +
      'and sees the run is successful.
- S-Bash-0545. User uses filespec with pattern, valid exclusions to ' +
      'download input resources for a step in bash and triggers the run ' +
      'and sees the run is successful.