### PR TITLE
Use template for Bash GitRepo tests.

### DIFF
--- a/tests/values/gitRepoValues.yml
+++ b/tests/values/gitRepoValues.yml
@@ -1,0 +1,29 @@
+GitHub:
+  Org_test_Automation:
+    path: jfbetapipeorg/Org_test_Automation
+  Org_test_Automation_bash:
+    path: jfbetapipeorg/Org_test_Automation_bash
+  Org_test_Automation_PowerShell:
+    path: jfbetapipeorg/Org_test_Automation_PowerShell
+
+GitHubEnterprise:
+  Org_test_Automation:
+    path: jfbetapipeorg/Org_test_Automation
+  test_automation:
+    path: jfbeta/test_automation
+
+GitLab:
+  test_automation:
+    path: jfbeta/test_automation
+
+BitbucketCloud:
+  jfrogtesting:
+    path: jfbeta/jfrogtesting
+  test_automation:
+    path: jfbeta/test_automation
+
+BitbucketServer:
+  automation:
+    path: PIP/automation
+  test_automation:
+    path: PIP/test_automation

--- a/tests/yaml/S_Bash_0136.yml
+++ b/tests/yaml/S_Bash_0136.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: S_Bash_0136_GitRepo
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipelines_S_Bash_0136

--- a/tests/yaml/S_Bash_0138.yml
+++ b/tests/yaml/S_Bash_0138.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
    - name: S_Bash_0138_GitRepo
      type: GitRepo
      configuration:
        gitProvider: s_gitHub
-       path: jfbetapipeorg/Org_test_Automation
+       path: {{ .Values.GitHub.Org_test_Automation.path }}
        branches:
          include: master
        buildOn:  # optional

--- a/tests/yaml/S_Bash_0139.yml
+++ b/tests/yaml/S_Bash_0139.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
    - name: S_Bash_0139_GitRepo
      type: GitRepo
      configuration:
        gitProvider: s_gitHub
-       path: jfbetapipeorg/Org_test_Automation
+       path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipelines_S_Bash_0139

--- a/tests/yaml/S_Bash_0142.yml
+++ b/tests/yaml/S_Bash_0142.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: S_Bash_0142_GitRepo
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipelines_S_Bash_0142
@@ -21,7 +24,7 @@ pipelines:
               [ ! -z "$res_S_Bash_0142_GitRepo_lastAuthorEmail" ]
             - |
               [ ! -z "$res_S_Bash_0142_GitRepo_gitProvider_token" ]
-            
+
             - |
               [ ! -z "$res_S_Bash_0142_GitRepo_isGitTag" ]
             - |
@@ -32,7 +35,7 @@ pipelines:
               [ ! -z "$res_S_Bash_0142_GitRepo_gitProvider_id" ]
             - |
               [ ! -z "$res_S_Bash_0142_GitRepo_integrationName" ]
-            
+
             - |
               [ ! -z "$res_S_Bash_0142_GitRepo_operation" ]
             - |
@@ -41,12 +44,12 @@ pipelines:
               [ ! -z "$res_S_Bash_0142_GitRepo_gitProvider_name" ]
             - |
               [ ! -z "$res_S_Bash_0142_GitRepo_gitProvider_url" ]
-            
+
             - |
               [ ! -z "$res_S_Bash_0142_GitRepo_gitRepoSourceDefaultBranch" ]
             - |
               [ ! -z "$res_S_Bash_0142_GitRepo_isTrigger" ]
-            
+
             - |
               [ ! -z "$res_S_Bash_0142_GitRepo_resourceId" ]
             - |
@@ -65,7 +68,7 @@ pipelines:
               [ ! -z "$res_S_Bash_0142_GitRepo_gitRepoRepositorySshUrl" ]
             - |
               [ ! -z "$res_S_Bash_0142_GitRepo_isRelease" ]
-            
+
             - |
               [ ! -z "$res_S_Bash_0142_GitRepo_committerLogin" ]
             - |
@@ -78,7 +81,7 @@ pipelines:
               [ ! -z "$res_S_Bash_0142_GitRepo_compareUrl" ]
             - |
               [ ! -z "$res_S_Bash_0142_GitRepo_repositoryProvider" ]
-            
+
             - |
               [ ! -z "$res_S_Bash_0142_GitRepo_sysPrivateDeployKey" ]
             - |
@@ -113,4 +116,3 @@ pipelines:
             #  [ ! -z "$res_S_Bash_0142_GitRepo_baseCommitRef" ]
             #- |
             #  [ ! -z "$res_S_Bash_0142_GitRepo_releasedAt" ]
-

--- a/tests/yaml/S_Bash_0143.yml
+++ b/tests/yaml/S_Bash_0143.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
    - name: S_Bash_0143_GitRepo
      type: GitRepo
      configuration:
        gitProvider: s_gitHub
-       path: jfbetapipeorg/Org_test_Automation
+       path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipelines_S_Bash_0143

--- a/tests/yaml/S_Bash_0147.yml
+++ b/tests/yaml/S_Bash_0147.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
    - name: S_Bash_0147_GitRepo
      type: GitRepo
      configuration:
        gitProvider: s_gitHub
-       path: jfbetapipeorg/Org_test_Automation
+       path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipelines_S_Bash_0147

--- a/tests/yaml/S_Bash_0475.yml
+++ b/tests/yaml/S_Bash_0475.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
    - name: S_Bash_0475_GitRepo
      type: GitRepo
      configuration:
        gitProvider: s_bitbucket
-       path: jfbeta/test_automation
+       path: {{ .Values.BitbucketCloud.test_automation.path }}
        branches:
          include: master
        buildOn:  # optional

--- a/tests/yaml/S_Bash_0476.yml
+++ b/tests/yaml/S_Bash_0476.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
    - name: S_Bash_0476_GitRepo
      type: GitRepo
      configuration:
        gitProvider: s_bitbucketServer
-       path: PIP/automation
+       path: {{ .Values.BitbucketServer.automation.path }}
        branches:
          include: master
        buildOn:  # optional

--- a/tests/yaml/S_Bash_0477.yml
+++ b/tests/yaml/S_Bash_0477.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
    - name: S_Bash_0477_GitRepo
      type: GitRepo
      configuration:
        gitProvider: s_gitlab
-       path: jfbeta/test_automation
+       path: {{ .Values.GitLab.test_automation.path }}
        branches:
          include: master
        buildOn:  # optional

--- a/tests/yaml/S_Bash_0478.yml
+++ b/tests/yaml/S_Bash_0478.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
    - name: S_Bash_0478_GitRepo
      type: GitRepo
      configuration:
        gitProvider: s_githubEnterprise
-       path: jfbetapipeorg/Org_test_Automation
+       path: {{ .Values.GitHubEnterprise.Org_test_Automation.path }}
        branches:
          include: master
        buildOn:  # optional

--- a/tests/yaml/S_Bash_0479.yml
+++ b/tests/yaml/S_Bash_0479.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
    - name: S_Bash_0479_GitRepo
      type: GitRepo
      configuration:
        gitProvider: s_bitbucket
-       path: jfbeta/test_automation
+       path: {{ .Values.BitbucketCloud.test_automation.path }}
 
 pipelines:
   - name: pipelines_S_Bash_0479

--- a/tests/yaml/S_Bash_0480.yml
+++ b/tests/yaml/S_Bash_0480.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
    - name: S_Bash_0480_GitRepo
      type: GitRepo
      configuration:
        gitProvider: s_bitbucketServer
-       path: PIP/automation
+       path: {{ .Values.BitbucketServer.automation.path }}
 
 pipelines:
   - name: pipelines_S_Bash_0480

--- a/tests/yaml/S_Bash_0481.yml
+++ b/tests/yaml/S_Bash_0481.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
    - name: S_Bash_0481_GitRepo
      type: GitRepo
      configuration:
        gitProvider: s_gitlab
-       path: jfbeta/test_automation
+       path: {{ .Values.GitLab.test_automation.path }}
 
 pipelines:
   - name: pipelines_S_Bash_0481

--- a/tests/yaml/S_Bash_0482.yml
+++ b/tests/yaml/S_Bash_0482.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
    - name: S_Bash_0482_GitRepo
      type: GitRepo
      configuration:
        gitProvider: s_githubEnterprise
-       path: jfbetapipeorg/Org_test_Automation
+       path: {{ .Values.GitHubEnterprise.Org_test_Automation.path }}
 
 pipelines:
   - name: pipelines_S_Bash_0482

--- a/tests/yaml/S_Bash_0483.yml
+++ b/tests/yaml/S_Bash_0483.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: S_Bash_0483_GitRepo
     type: GitRepo
     configuration:
       gitProvider: s_bitbucket
-      path: jfbeta/test_automation
+      path: {{ .Values.BitbucketCloud.test_automation.path }}
 
 pipelines:
   - name: pipelines_S_Bash_0483
@@ -16,7 +19,7 @@ pipelines:
         execution:
           onExecute:
             - echo "executing step..."
-            
+
             - |
               [ ! -z "$res_S_Bash_0483_GitRepo_gitRepoRepositoryUrl" ]
             - |
@@ -24,7 +27,7 @@ pipelines:
             - |
               [ ! -z "$res_S_Bash_0483_GitRepo_gitProvider_masterName" ]
             - |
-              [ ! -z "$res_S_Bash_0483_GitRepo_gitProvider_username" ]  
+              [ ! -z "$res_S_Bash_0483_GitRepo_gitProvider_username" ]
             - |
               [ ! -z "$res_S_Bash_0483_GitRepo_lastAuthorEmail" ]
             - |
@@ -48,7 +51,7 @@ pipelines:
             - |
               [ ! -z "$res_S_Bash_0483_GitRepo_commitMessage" ]
             - |
-              [ ! -z "$res_S_Bash_0483_GitRepo_isPullRequest" ] 
+              [ ! -z "$res_S_Bash_0483_GitRepo_isPullRequest" ]
             - |
               [ ! -z "$res_S_Bash_0483_GitRepo_gitProvider_token" ]
             - |
@@ -60,7 +63,7 @@ pipelines:
             - |
               [ ! -z "$res_S_Bash_0483_GitRepo_gitRepoRepositoryHttpsUrl" ]
             - |
-              [ ! -z "$res_S_Bash_0483_GitRepo_isPullRequestClose" ]   
+              [ ! -z "$res_S_Bash_0483_GitRepo_isPullRequestClose" ]
             - |
               [ ! -z "$res_S_Bash_0483_GitRepo_integrationName" ]
             - |
@@ -90,7 +93,7 @@ pipelines:
             - |
               [ ! -z "$res_S_Bash_0483_GitRepo_gitTagMessage" ]
 
-            
+
 #             empty fields
 #             - |
 #               [ ! -z "$res_S_Bash_0483_GitRepo_gitTagName" ]
@@ -108,5 +111,3 @@ pipelines:
 #               [ ! -z "$res_S_Bash_0483_GitRepo_releasedAt" ]
 #             - |
 #               [ ! -z "$res_S_Bash_0483_GitRepo_pullRequestNumber" ]
-            
-

--- a/tests/yaml/S_Bash_0484.yml
+++ b/tests/yaml/S_Bash_0484.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: S_Bash_0484_GitRepo
     type: GitRepo
     configuration:
       gitProvider: s_bitbucketServer
-      path: PIP/test_automation
+      path: {{ .Values.BitbucketServer.test_automation.path }}
 
 pipelines:
   - name: pipelines_S_Bash_0484
@@ -20,7 +23,7 @@ pipelines:
               [ ! -z "$res_S_Bash_0484_GitRepo_lastAuthorEmail" ]
             - |
               [ ! -z "$res_S_Bash_0484_GitRepo_gitProvider_token" ]
-            
+
             - |
               [ ! -z "$res_S_Bash_0484_GitRepo_isGitTag" ]
             - |
@@ -31,7 +34,7 @@ pipelines:
               [ ! -z "$res_S_Bash_0484_GitRepo_gitProvider_id" ]
             - |
               [ ! -z "$res_S_Bash_0484_GitRepo_integrationName" ]
-            
+
             - |
               [ ! -z "$res_S_Bash_0484_GitRepo_operation" ]
             - |
@@ -40,12 +43,12 @@ pipelines:
               [ ! -z "$res_S_Bash_0484_GitRepo_gitProvider_name" ]
             - |
               [ ! -z "$res_S_Bash_0484_GitRepo_gitProvider_url" ]
-            
+
             - |
               [ ! -z "$res_S_Bash_0484_GitRepo_gitRepoSourceDefaultBranch" ]
             - |
               [ ! -z "$res_S_Bash_0484_GitRepo_isTrigger" ]
-            
+
             - |
               [ ! -z "$res_S_Bash_0484_GitRepo_resourceId" ]
             - |
@@ -64,7 +67,7 @@ pipelines:
               [ ! -z "$res_S_Bash_0484_GitRepo_gitRepoRepositorySshUrl" ]
             - |
               [ ! -z "$res_S_Bash_0484_GitRepo_isRelease" ]
-            
+
             - |
               [ ! -z "$res_S_Bash_0484_GitRepo_committerLogin" ]
             - |
@@ -77,7 +80,7 @@ pipelines:
               [ ! -z "$res_S_Bash_0484_GitRepo_compareUrl" ]
             - |
               [ ! -z "$res_S_Bash_0484_GitRepo_repositoryProvider" ]
-            
+
             - |
               [ ! -z "$res_S_Bash_0484_GitRepo_sysPrivateDeployKey" ]
             - |

--- a/tests/yaml/S_Bash_0485.yml
+++ b/tests/yaml/S_Bash_0485.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: S_Bash_0485_GitRepo
     type: GitRepo
     configuration:
       gitProvider: s_gitlab
-      path: jfbeta/test_automation
+      path: {{ .Values.GitLab.test_automation.path }}
 
 pipelines:
   - name: pipelines_S_Bash_0485
@@ -21,7 +24,7 @@ pipelines:
               [ ! -z "$res_S_Bash_0485_GitRepo_lastAuthorEmail" ]
             - |
               [ ! -z "$res_S_Bash_0485_GitRepo_gitProvider_token" ]
-            
+
             - |
               [ ! -z "$res_S_Bash_0485_GitRepo_isGitTag" ]
             - |
@@ -32,7 +35,7 @@ pipelines:
               [ ! -z "$res_S_Bash_0485_GitRepo_gitProvider_id" ]
             - |
               [ ! -z "$res_S_Bash_0485_GitRepo_integrationName" ]
-            
+
             - |
               [ ! -z "$res_S_Bash_0485_GitRepo_operation" ]
             - |
@@ -41,12 +44,12 @@ pipelines:
               [ ! -z "$res_S_Bash_0485_GitRepo_gitProvider_name" ]
             - |
               [ ! -z "$res_S_Bash_0485_GitRepo_gitProvider_url" ]
-            
+
             - |
               [ ! -z "$res_S_Bash_0485_GitRepo_gitRepoSourceDefaultBranch" ]
             - |
               [ ! -z "$res_S_Bash_0485_GitRepo_isTrigger" ]
-            
+
             - |
               [ ! -z "$res_S_Bash_0485_GitRepo_resourceId" ]
             - |
@@ -65,7 +68,7 @@ pipelines:
               [ ! -z "$res_S_Bash_0485_GitRepo_gitRepoRepositorySshUrl" ]
             - |
               [ ! -z "$res_S_Bash_0485_GitRepo_isRelease" ]
-            
+
             - |
               [ ! -z "$res_S_Bash_0485_GitRepo_committerLogin" ]
             - |
@@ -78,7 +81,7 @@ pipelines:
               [ ! -z "$res_S_Bash_0485_GitRepo_compareUrl" ]
             - |
               [ ! -z "$res_S_Bash_0485_GitRepo_repositoryProvider" ]
-            
+
             - |
               [ ! -z "$res_S_Bash_0485_GitRepo_sysPrivateDeployKey" ]
             - |

--- a/tests/yaml/S_Bash_0486.yml
+++ b/tests/yaml/S_Bash_0486.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: S_Bash_0486_GitRepo
     type: GitRepo
     configuration:
       gitProvider: s_githubEnterprise
-      path: jfbeta/test_automation
+      path: {{ .Values.GitHubEnterprise.test_automation.path }}
 
 pipelines:
   - name: pipelines_S_Bash_0486
@@ -20,7 +23,7 @@ pipelines:
               [ ! -z "$res_S_Bash_0486_GitRepo_lastAuthorEmail" ]
             - |
               [ ! -z "$res_S_Bash_0486_GitRepo_gitProvider_token" ]
-            
+
             - |
               [ ! -z "$res_S_Bash_0486_GitRepo_isGitTag" ]
             - |
@@ -31,7 +34,7 @@ pipelines:
               [ ! -z "$res_S_Bash_0486_GitRepo_gitProvider_id" ]
             - |
               [ ! -z "$res_S_Bash_0486_GitRepo_integrationName" ]
-            
+
             - |
               [ ! -z "$res_S_Bash_0486_GitRepo_operation" ]
             - |
@@ -40,12 +43,12 @@ pipelines:
               [ ! -z "$res_S_Bash_0486_GitRepo_gitProvider_name" ]
             - |
               [ ! -z "$res_S_Bash_0486_GitRepo_gitProvider_url" ]
-            
+
             - |
               [ ! -z "$res_S_Bash_0486_GitRepo_gitRepoSourceDefaultBranch" ]
             - |
               [ ! -z "$res_S_Bash_0486_GitRepo_isTrigger" ]
-            
+
             - |
               [ ! -z "$res_S_Bash_0486_GitRepo_resourceId" ]
             - |
@@ -64,7 +67,7 @@ pipelines:
               [ ! -z "$res_S_Bash_0486_GitRepo_gitRepoRepositorySshUrl" ]
             - |
               [ ! -z "$res_S_Bash_0486_GitRepo_isRelease" ]
-            
+
             - |
               [ ! -z "$res_S_Bash_0486_GitRepo_committerLogin" ]
             - |
@@ -77,7 +80,7 @@ pipelines:
               [ ! -z "$res_S_Bash_0486_GitRepo_compareUrl" ]
             - |
               [ ! -z "$res_S_Bash_0486_GitRepo_repositoryProvider" ]
-            
+
             - |
               [ ! -z "$res_S_Bash_0486_GitRepo_sysPrivateDeployKey" ]
             - |

--- a/tests/yaml/S_Bash_0487.yml
+++ b/tests/yaml/S_Bash_0487.yml
@@ -1,10 +1,12 @@
-  
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
    - name: S_Bash_0487_GitRepo
      type: GitRepo
      configuration:
        gitProvider: s_bitbucket
-       path: jfbeta/test_automation
+       path: {{ .Values.BitbucketCloud.test_automation.path }}
 
 pipelines:
   - name: pipelines_S_Bash_0487

--- a/tests/yaml/S_Bash_0488.yml
+++ b/tests/yaml/S_Bash_0488.yml
@@ -1,10 +1,12 @@
-  
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
    - name: S_Bash_0488_GitRepo
      type: GitRepo
      configuration:
        gitProvider: s_bitbucketServer
-       path: PIP/automation
+       path: {{ .Values.BitbucketServer.automation.path }}
 
 pipelines:
   - name: pipelines_S_Bash_0488

--- a/tests/yaml/S_Bash_0489.yml
+++ b/tests/yaml/S_Bash_0489.yml
@@ -1,10 +1,12 @@
-  
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
    - name: S_Bash_0489_GitRepo
      type: GitRepo
      configuration:
        gitProvider: s_gitlab
-       path: jfbeta/test_automation
+       path: {{ .Values.GitLab.test_automation.path }}
 
 pipelines:
   - name: pipelines_S_Bash_0489

--- a/tests/yaml/S_Bash_0490.yml
+++ b/tests/yaml/S_Bash_0490.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
    - name: S_Bash_0490_GitRepo
      type: GitRepo
      configuration:
        gitProvider: s_githubEnterprise
-       path: jfbetapipeorg/Org_test_Automation
+       path: {{ .Values.GitHubEnterprise.Org_test_Automation.path }}
 
 pipelines:
   - name: pipelines_S_Bash_0490

--- a/tests/yaml/S_Bash_0491.yml
+++ b/tests/yaml/S_Bash_0491.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
    - name: S_Bash_0491_GitRepo
      type: GitRepo
      configuration:
        gitProvider: s_bitbucket
-       path: jfbeta/test_automation
+       path: {{ .Values.BitbucketCloud.test_automation.path }}
 
 pipelines:
   - name: pipelines_S_Bash_0491

--- a/tests/yaml/S_Bash_0492.yml
+++ b/tests/yaml/S_Bash_0492.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
    - name: S_Bash_0492_GitRepo
      type: GitRepo
      configuration:
        gitProvider: s_bitbucketServer
-       path: PIP/automation
+       path: {{ .Values.BitbucketServer.automation.path }}
 
 pipelines:
   - name: pipelines_S_Bash_0491

--- a/tests/yaml/S_Bash_0493.yml
+++ b/tests/yaml/S_Bash_0493.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
    - name: S_Bash_0493_GitRepo
      type: GitRepo
      configuration:
        gitProvider: s_gitlab
-       path: jfbeta/test_automation
+       path: {{ .Values.GitLab.test_automation.path }}
 
 pipelines:
   - name: pipelines_S_Bash_0493

--- a/tests/yaml/S_Bash_0494.yml
+++ b/tests/yaml/S_Bash_0494.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
    - name: S_Bash_0494_GitRepo
      type: GitRepo
      configuration:
        gitProvider: s_githubEnterprise
-       path: jfbetapipeorg/Org_test_Automation
+       path: {{ .Values.GitHubEnterprise.Org_test_Automation.path }}
 
 pipelines:
   - name: pipelines_S_Bash_0494

--- a/tests/yaml/S_Bash_0495.yml
+++ b/tests/yaml/S_Bash_0495.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: S_Bash_0495_GitRepo
     type: GitRepo
     configuration:
       gitProvider: s_bitbucket
-      path: jfbeta/jfrogtesting
+      path: {{ .Values.BitbucketCloud.jfrogtesting.path }}
 
 pipelines:
   - name: pipelines_S_Bash_0495

--- a/tests/yaml/S_Bash_0496.yml
+++ b/tests/yaml/S_Bash_0496.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: S_Bash_0496_GitRepo
     type: GitRepo
     configuration:
       gitProvider: s_bitbucketServer
-      path: PIP/automation
+      path: {{ .Values.BitbucketServer.automation.path }}
 
 pipelines:
   - name: pipelines_S_Bash_0496

--- a/tests/yaml/S_Bash_0497.yml
+++ b/tests/yaml/S_Bash_0497.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: S_Bash_0497_GitRepo
     type: GitRepo
     configuration:
       gitProvider: s_gitlab
-      path: jfbeta/test_automation
+      path: {{ .Values.GitLab.test_automation.path }}
 
 pipelines:
   - name: pipelines_S_Bash_0497

--- a/tests/yaml/S_Bash_0498.yml
+++ b/tests/yaml/S_Bash_0498.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: S_Bash_0498_GitRepo
     type: GitRepo
     configuration:
       gitProvider: s_githubEnterprise
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHubEnterprise.Org_test_Automation.path }}
 
 pipelines:
   - name: pipelines_S_Bash_0498

--- a/tests/yaml/S_Bash_0509.yml
+++ b/tests/yaml/S_Bash_0509.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
    - name: S_Bash_0509_GitRepo
      type: GitRepo
      configuration:
        gitProvider: s_gitHub
-       path: jfbetapipeorg/Org_test_Automation
+       path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipelines_S_Bash_0509

--- a/tests/yaml/S_Bash_Util_0001.yml
+++ b/tests/yaml/S_Bash_Util_0001.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: repo_pipe
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_Bash_Util_0001

--- a/tests/yaml/S_Bash_Util_0002.yml
+++ b/tests/yaml/S_Bash_Util_0002.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: repo_pipe
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_Bash_Util_0002

--- a/tests/yaml/S_Bash_Util_0003.yml
+++ b/tests/yaml/S_Bash_Util_0003.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: repo_pipe
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_Bash_Util_0003

--- a/tests/yaml/S_Bash_Util_0004.yml
+++ b/tests/yaml/S_Bash_Util_0004.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: repo_pipe
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_Bash_Util_0004

--- a/tests/yaml/S_Bash_Util_0005.yml
+++ b/tests/yaml/S_Bash_Util_0005.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: repo_pipe
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_Bash_Util_0005

--- a/tests/yaml/S_Bash_Util_0006.yml
+++ b/tests/yaml/S_Bash_Util_0006.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: repo_pipe
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_Bash_Util_0006

--- a/tests/yaml/S_Bash_Util_0007.yml
+++ b/tests/yaml/S_Bash_Util_0007.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: repo_pipe
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_Bash_Util_0007

--- a/tests/yaml/S_Bash_Util_0008.yml
+++ b/tests/yaml/S_Bash_Util_0008.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: repo_pipe
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_Bash_Util_0008

--- a/tests/yaml/S_Bash_Util_0009.yml
+++ b/tests/yaml/S_Bash_Util_0009.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: repo_pipe
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_Bash_Util_0009

--- a/tests/yaml/S_Bash_Util_0010.yml
+++ b/tests/yaml/S_Bash_Util_0010.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: repo_pipe
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_Bash_Util_0010

--- a/tests/yaml/S_Bash_Util_0011.yml
+++ b/tests/yaml/S_Bash_Util_0011.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: repo_pipe
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_Bash_Util_0011

--- a/tests/yaml/S_Bash_Util_0012.yml
+++ b/tests/yaml/S_Bash_Util_0012.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: repo_pipe
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_Bash_Util_0012

--- a/tests/yaml/S_Bash_Util_0013.yml
+++ b/tests/yaml/S_Bash_Util_0013.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: repo_pipe
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_Bash_Util_0013

--- a/tests/yaml/S_Bash_Util_0014.yml
+++ b/tests/yaml/S_Bash_Util_0014.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: repo_pipe
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_Bash_Util_0014

--- a/tests/yaml/S_Bash_Util_0015.yml
+++ b/tests/yaml/S_Bash_Util_0015.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: repo_pipe
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_Bash_Util_0015

--- a/tests/yaml/S_Bash_Util_0016.yml
+++ b/tests/yaml/S_Bash_Util_0016.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: repo_pipe
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_Bash_Util_0016

--- a/tests/yaml/S_Bash_Util_0017.yml
+++ b/tests/yaml/S_Bash_Util_0017.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: repo_pipe
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_Bash_Util_0017

--- a/tests/yaml/S_Bash_Util_0018.yml
+++ b/tests/yaml/S_Bash_Util_0018.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: repo_pipe
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_Bash_Util_0018

--- a/tests/yaml/S_Bash_Util_Notification.yml
+++ b/tests/yaml/S_Bash_Util_Notification.yml
@@ -1,10 +1,12 @@
-resources:
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
   - name: S_Bash_Util_Notification_Repo
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
-          
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
+
 pipelines:
   - name: S_Bash_Util_Notification_pipe
     steps:
@@ -16,11 +18,9 @@ pipelines:
             - name: BSU_slack
           inputResources:
             - name: S_Bash_Util_Notification_Repo
-            
+
         execution:
-          onExecute: 
-            - pushd $res_S_Bash_Util_Notification_Repo_resourcePath    
+          onExecute:
+            - pushd $res_S_Bash_Util_Notification_Repo_resourcePath
             - send_notification slack
             - popd
-
-

--- a/tests/yaml/S_Bash_UtilityFunction.yml
+++ b/tests/yaml/S_Bash_UtilityFunction.yml
@@ -1,10 +1,13 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: S_Bash_UtilityFunction_repo
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation           
-      
+      path: {{ .Values.GitHub.Org_test_Automation.path }}      
+
 pipelines:
   - name: S_Bash_UtilityFunction_pipeline
     steps:
@@ -15,42 +18,42 @@ pipelines:
             - name: s_gitHub
           inputResources:
             - name: S_Bash_UtilityFunction_repo
-            
+
         execution:
-          onExecute: 
+          onExecute:
             - printenv
             - bump_semver v3.0.0 major
             - bump_semver v3.0.0 minor
             - bump_semver v3.0.0 patch
             - bump_semver v3.0.0 beta
-            - pushd $res_S_Bash_UtilityFunction_repo_resourcePath    
+            - pushd $res_S_Bash_UtilityFunction_repo_resourcePath
             - touch keys
             - echo "name =$res_S_Bash_UtilityFunction_repo_gitProvider_name" >> keys
-            - replace_envs $PWD/keys 
+            - replace_envs $PWD/keys
             - cat keys
             - touch file.txt
             - echo "Hello frog" >> file.txt
             - touch test.txt
             - echo "Hello pipelines team" >> test.txt
             - compare_git --resource S_Bash_UtilityFunction_repo --commit-range HEAD~3..HEAD UtilityFunction.yml
-            - update_commit_status S_Bash_UtilityFunction_repo --status failure --message "My description 123" --context "stepB"            
+            - update_commit_status S_Bash_UtilityFunction_repo --status failure --message "My description 123" --context "stepB"
             - read_json $res_S_Bash_UtilityFunction_repo_resourcePath/tests/yaml/sample.json "DOCKER_USERNAME"
-            - add_cache_files $PWD/file.txt jfrog_pipe 
+            - add_cache_files $PWD/file.txt jfrog_pipe
             - add_run_variables imageTag="master"
             #- add_run_variables runVaribale="foo   123"
             - add_run_files $PWD/test.txt jfrog
             - add_pipeline_variables scm=$int_s_gitHub_masterName
             # - add_pipeline_variables pipelineVaribale="foo  bar"
-            - export_run_variables 
-            - export_pipeline_variables          
+            - export_run_variables
+            - export_pipeline_variables
             - add_pipeline_files $PWD/file.txt jfrog_pipeline
             - find_resource_variable S_Bash_UtilityFunction_repo resourcePath
             - restore_cache_files jfrog_pipe $PWD/file.txt
             - cat file.txt
-            - openssl genrsa -out key.pem 1024 
+            - openssl genrsa -out key.pem 1024
             - openssl rsa -in key.pem -text -noout
-            - openssl rsa -in key.pem -pubout -out pub.pem 
-            - openssl rsa -in pub.pem -pubin -text -noout 
+            - openssl rsa -in key.pem -pubout -out pub.pem
+            - openssl rsa -in pub.pem -pubin -text -noout
             - encrypt_string "secretValue" --key pub.pem
             - encrypted=$(encrypt_string "secretValue" --key pub.pem)
             - echo "$encrypted"
@@ -61,13 +64,13 @@ pipelines:
             - encrypt_file --output encrypted.txt crypt.txt --key pub.pem
             - cat encrypted.txt
             - decrypt_file encrypted.txt --output decrypted.txt --key key.pem
-            - cat decrypted.txt 
+            - cat decrypted.txt
             - python -m py_compile tests/core/sampleExecutionFile/calc.py
             - pip install --upgrade pip
             - hash -d pip
-            - pip install pytest           
+            - pip install pytest
             - py.test --verbose --junit-xml test-reports/results.xml tests/core/sampleExecutionFile/test_calc.py
-            - save_tests $res_S_Bash_UtilityFunction_repo_resourcePath/test-reports/results.xml             
+            - save_tests $res_S_Bash_UtilityFunction_repo_resourcePath/test-reports/results.xml
             - popd
 
       - name: S_Bash_UtilityFunction_step_2
@@ -78,7 +81,7 @@ pipelines:
           inputSteps:
             - name: S_Bash_UtilityFunction
           inputResources:
-            - name: S_Bash_UtilityFunction_repo                
+            - name: S_Bash_UtilityFunction_repo
         execution:
           onExecute:
             - printenv
@@ -99,7 +102,7 @@ pipelines:
           inputResources:
             - name: S_Bash_UtilityFunction_repo
           inputSteps:
-            - name: S_Bash_UtilityFunction_step_2   
+            - name: S_Bash_UtilityFunction_step_2
 
         execution:
           onExecute:
@@ -109,17 +112,17 @@ pipelines:
 #             - execute_command [--retry] printen
 #             - retry_command printen
             - popd
-            
+
       - name: S_Bash_UtilityFunction_step_4
         type: PowerShell
         configuration:
-          nodePool: win_2019        
+          nodePool: win_2019
           integrations:
             - name: s_gitHub
           inputResources:
             - name: S_Bash_UtilityFunction_repo
           inputSteps:
-            - name: S_Bash_UtilityFunction_step_3         
+            - name: S_Bash_UtilityFunction_step_3
 
         execution:
           onExecute:
@@ -127,5 +130,3 @@ pipelines:
             - $runVariable
             - $scm
             - $pipelineVaribale
-
-         

--- a/tests/yaml/S_Bash_UtilityFunctionWriteOutput.yml
+++ b/tests/yaml/S_Bash_UtilityFunctionWriteOutput.yml
@@ -1,19 +1,20 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: S_Bash_Util_Writeoutput_Repo
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
-      
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
+
   - name: S_Bash_Util_Writeoutput_Image
     type: Image
     configuration:
        registry: BSU_DockerRegistry
        imageName: shipbeta00/ubuntu
        imageTag: master
-     
-            
-      
+
 pipelines:
   - name: S_Bash_UtilityFunctionWriteOutput_pipeline
     steps:
@@ -23,14 +24,12 @@ pipelines:
           integrations:
             - name: s_gitHub
           inputResources:
-            - name: S_Bash_Util_Writeoutput_Repo  
+            - name: S_Bash_Util_Writeoutput_Repo
           outputResources:
             - name: S_Bash_Util_Writeoutput_Image
-            
+
         execution:
-          onExecute: 
-            - pushd $res_S_Bash_Util_Writeoutput_Repo_resourcePath  
-            - write_output S_Bash_Util_Writeoutput_Image "imageTag=master"  
+          onExecute:
+            - pushd $res_S_Bash_Util_Writeoutput_Repo_resourcePath
+            - write_output S_Bash_Util_Writeoutput_Image "imageTag=master"
             - popd
-
-

--- a/tests/yaml/S_Matrix_0023.yml
+++ b/tests/yaml/S_Matrix_0023.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: script_repo1
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: Pipelines_matrix


### PR DESCRIPTION
Uses a local template for all GitRepo inputs to make updating the repository used easier.  The GitHub test cases that are not currently skipped have been verified to still work; all other YMLs belong to test cases that are currently skipped.