### PR TITLE
More CreateReleaseBundle tests.

### DIFF
--- a/tests/yaml/S_Bash_6237_001.yml
+++ b/tests/yaml/S_Bash_6237_001.yml
@@ -1,0 +1,11 @@
+pipelines:
+  - name: pipeline_S_Bash_6237_001
+    steps:
+      - name: S_Bash_6237_001_1
+        type: Bash
+        configuration:
+          integrations:
+            - name: s_artifactory
+        execution:
+          onExecute:
+            - save_artifact_info releaseBundle output.json

--- a/tests/yaml/S_CreateReleaseBundle_0005.yml
+++ b/tests/yaml/S_CreateReleaseBundle_0005.yml
@@ -42,3 +42,18 @@ pipelines:
             - name: S_CreateReleaseBundle_0005_BuildInfo
           outputResources:
             - name: S_CreateReleaseBundle_0005_ReleaseBundle
+
+      - name: S_CreateReleaseBundle_0005_3
+        type: Bash
+        configuration:
+          inputSteps:
+            - name: S_CreateReleaseBundle_0005_2
+          integrations:
+            - name: s_artifactory
+            - name: s_distribution
+        execution:
+          onExecute:
+            - curlOptions="--silent --retry 3 -w %{http_code} -u $int_s_distribution_user:$int_s_distribution_apikey"
+            - if [ "$no_verify_ssl" == "true" ]; then curlOptions+=" --insecure"; fi
+            - "status=$(curl $curlOptions -H 'Content-Type: application/json' -XGET \"$int_s_distribution_url/api/v1/release_bundle/${JFROG_CLI_BUILD_NAME}/${run_id}\" --output $step_tmp_dir/response)"
+            - 'if [ "$status" != "404" ]; then echo "status: $status"; return 1; fi'

--- a/tests/yaml/S_CreateReleaseBundle_0006.yml
+++ b/tests/yaml/S_CreateReleaseBundle_0006.yml
@@ -53,19 +53,10 @@ pipelines:
             - distributionUrl="$res_S_CreateReleaseBundle_0006_ReleaseBundle_sourceDistribution_url"
             - releaseBundleName=$(find_resource_variable S_CreateReleaseBundle_0006_ReleaseBundle name)
             - releaseBundleVersion=$(find_resource_variable S_CreateReleaseBundle_0006_ReleaseBundle version)
-            - "echo '{\"dry_run\": false, \"distribution_rules\": [{\"site_name\": \"*\"}], \"on_success\": \"delete\"}' > $step_tmp_dir/distribution_payload"
-            - curlOptions="--silent --retry 3 -w %{http_code} -u $res_S_CreateReleaseBundle_0006_ReleaseBundle_sourceDistribution_user:$res_S_CreateReleaseBundle_0006_ReleaseBundle_sourceDistribution_apikey"
-            - if [ "$no_verify_ssl" == "true" ]; then curlOptions+=" --insecure"; fi
-            - "status=$(curl $curlOptions -H 'Content-Type: application/json' -XPOST \"$distributionUrl/api/v1/distribution/$releaseBundleName/$releaseBundleVersion/delete\" --output $step_tmp_dir/response -T \"$step_tmp_dir/distribution_payload\")"
-            - response=$(cat $step_tmp_dir/response)
-            - if [ $status -gt 299 ]; then return 1; fi
-            - idFromResponse=$(echo $response | tr -d '[:space:]' | grep -o "\"id\":.*")
-            - trackerId=$(echo ${idFromResponse:5} | cut -d "," -f 1)
-            - if [ -z "$trackerId" ]; then return 1; fi
-            - rm -f \$step_tmp_dir/response
-            - distributionStatus="$(curl -XGET $curlOptions $distributionUrl/api/v1/release_bundle/$releaseBundleName/$releaseBundleVersion/distribution/$trackerId --output /dev/null)"
-            - while [ $distributionStatus -lt 299 ]; do sleep 5 && distributionStatus="$(curl -XGET $curlOptions $distributionUrl/api/v1/release_bundle/$releaseBundleName/$releaseBundleVersion/distribution/$trackerId --output /dev/null)"; done
-            - if [ $distributionStatus != 404 ]; then return 1; fi
+            - jfrog config add distribution --overwrite --insecure-tls=$no_verify_ssl --dist-url $distributionUrl --user $res_S_CreateReleaseBundle_0006_ReleaseBundle_sourceDistribution_user --apikey $res_S_CreateReleaseBundle_0006_ReleaseBundle_sourceDistribution_apikey --interactive=false
+            - jfrog config use distribution
+            - jfrog rt release-bundle-delete --delete-from-dist=true --insecure-tls=$no_verify_ssl $releaseBundleName $releaseBundleVersion
+            - jfrog config remove distribution
             - echo "Checking resource..."
             - if [ "$res_S_CreateReleaseBundle_0006_ReleaseBundle_name" != "${JFROG_CLI_BUILD_NAME}" ]; then return 1; fi
             - if [ "$res_S_CreateReleaseBundle_0006_ReleaseBundle_version" != "${run_id}" ]; then return 1; fi

--- a/tests/yaml/S_CreateReleaseBundle_0007.yml
+++ b/tests/yaml/S_CreateReleaseBundle_0007.yml
@@ -54,19 +54,10 @@ pipelines:
             - distributionUrl="$res_S_CreateReleaseBundle_0007_ReleaseBundle_sourceDistribution_url"
             - releaseBundleName=$(find_resource_variable S_CreateReleaseBundle_0007_ReleaseBundle name)
             - releaseBundleVersion=$(find_resource_variable S_CreateReleaseBundle_0007_ReleaseBundle version)
-            - "echo '{\"dry_run\": false, \"distribution_rules\": [{\"site_name\": \"*\"}], \"on_success\": \"delete\"}' > $step_tmp_dir/distribution_payload"
-            - curlOptions="--silent --retry 3 -w %{http_code} -u $res_S_CreateReleaseBundle_0007_ReleaseBundle_sourceDistribution_user:$res_S_CreateReleaseBundle_0007_ReleaseBundle_sourceDistribution_apikey"
-            - if [ "$no_verify_ssl" == "true" ]; then curlOptions+=" --insecure"; fi
-            - "status=$(curl $curlOptions -H 'Content-Type: application/json' -XPOST \"$distributionUrl/api/v1/distribution/$releaseBundleName/$releaseBundleVersion/delete\" --output $step_tmp_dir/response -T \"$step_tmp_dir/distribution_payload\")"
-            - response=$(cat $step_tmp_dir/response)
-            - if [ $status -gt 299 ]; then return 1; fi
-            - idFromResponse=$(echo $response | tr -d '[:space:]' | grep -o "\"id\":.*")
-            - trackerId=$(echo ${idFromResponse:5} | cut -d "," -f 1)
-            - if [ -z "$trackerId" ]; then return 1; fi
-            - rm -f \$step_tmp_dir/response
-            - distributionStatus="$(curl -XGET $curlOptions $distributionUrl/api/v1/release_bundle/$releaseBundleName/$releaseBundleVersion/distribution/$trackerId --output /dev/null)"
-            - while [ $distributionStatus -lt 299 ]; do sleep 5 && distributionStatus="$(curl -XGET $curlOptions $distributionUrl/api/v1/release_bundle/$releaseBundleName/$releaseBundleVersion/distribution/$trackerId --output /dev/null)"; done
-            - if [ $distributionStatus != 404 ]; then return 1; fi
+            - jfrog config add distribution --overwrite --insecure-tls=$no_verify_ssl --dist-url $distributionUrl --user $res_S_CreateReleaseBundle_0007_ReleaseBundle_sourceDistribution_user --apikey $res_S_CreateReleaseBundle_0007_ReleaseBundle_sourceDistribution_apikey --interactive=false
+            - jfrog config use distribution
+            - jfrog rt release-bundle-delete --delete-from-dist=true --insecure-tls=$no_verify_ssl $releaseBundleName $releaseBundleVersion
+            - jfrog config remove distribution
             - echo "Checking resource..."
             - if [ "$res_S_CreateReleaseBundle_0007_ReleaseBundle_name" != "${JFROG_CLI_BUILD_NAME}" ]; then return 1; fi
             - if [ "$res_S_CreateReleaseBundle_0007_ReleaseBundle_version" != "${run_id}" ]; then return 1; fi

--- a/tests/yaml/S_CreateReleaseBundle_6237_001.yml
+++ b/tests/yaml/S_CreateReleaseBundle_6237_001.yml
@@ -1,0 +1,61 @@
+resources:
+  - name: S_CreateReleaseBundle_6237_001_Aql
+    type: Aql
+    configuration:
+      sourceArtifactory: s_artifactory
+      query: 'items.find({"$and": [{"repo": {"$eq": "test-automation-generic-local"}}, {"name": {"$match": "S_CreateReleaseBundle_6237_001.txt"}}]})'
+
+  - name: S_CreateReleaseBundle_6237_001_ReleaseBundle
+    type: ReleaseBundle
+    configuration:
+      sourceDistribution: s_distribution
+      name: name
+      version: '1'
+
+pipelines:
+  - name: pipeline_S_CreateReleaseBundle_6237_001
+    steps:
+      - name: S_CreateReleaseBundle_6237_001_1
+        type: Bash
+        configuration:
+          integrations:
+            - name: s_artifactory
+          outputResources:
+            - name: S_CreateReleaseBundle_6237_001_Aql
+        execution:
+          onExecute:
+            - echo "${run_id}" > S_CreateReleaseBundle_6237_001.txt
+            - jfrog rt upload S_CreateReleaseBundle_6237_001.txt test-automation-generic-local --insecure-tls=$no_verify_ssl
+
+      - name: S_CreateReleaseBundle_6237_001_2
+        type: CreateReleaseBundle
+        configuration:
+          releaseBundleName: ${JFROG_CLI_BUILD_NAME}
+          releaseBundleVersion: ${run_id}
+          dryRun: false
+          inputResources:
+            - name: S_CreateReleaseBundle_6237_001_Aql
+          outputResources:
+            - name: S_CreateReleaseBundle_6237_001_ReleaseBundle
+
+      - name: S_CreateReleaseBundle_6237_001_3
+        type: Bash
+        configuration:
+          inputResources:
+            - name: S_CreateReleaseBundle_6237_001_ReleaseBundle
+          integrations:
+            - name: s_artifactory
+            - name: s_distribution
+        execution:
+          onExecute:
+            - echo "Deleting release bundle..."
+            - jfrog config add distribution --overwrite --insecure-tls=$no_verify_ssl --dist-url $int_s_distribution_url --user $int_s_distribution_user --apikey $int_s_distribution_apikey --interactive=false
+            - jfrog config use distribution
+            - releaseBundleName=$(find_resource_variable S_CreateReleaseBundle_6237_001_ReleaseBundle name)
+            - releaseBundleVersion=$(find_resource_variable S_CreateReleaseBundle_6237_001_ReleaseBundle version)
+            - jfrog rt release-bundle-delete --delete-from-dist=true --insecure-tls=$no_verify_ssl $releaseBundleName $releaseBundleVersion
+            - jfrog config remove distribution
+            - echo "Checking resource..."
+            - if [ "$res_S_CreateReleaseBundle_6237_001_ReleaseBundle_name" != "${JFROG_CLI_BUILD_NAME}" ]; then return 1; fi
+            - if [ "$res_S_CreateReleaseBundle_6237_001_ReleaseBundle_version" != "${run_id}" ]; then return 1; fi
+            - if [ "$res_S_CreateReleaseBundle_6237_001_ReleaseBundle_isSigned" == "true" ]; then return 1; fi

--- a/tests/yaml/S_CreateReleaseBundle_6237_002.yml
+++ b/tests/yaml/S_CreateReleaseBundle_6237_002.yml
@@ -1,0 +1,68 @@
+resources:
+  - name: S_CreateReleaseBundle_6237_002_Aql
+    type: Aql
+    configuration:
+      sourceArtifactory: s_artifactory
+      query: 'items.find({"$and": [{"repo": {"$eq": "test-automation-generic-local"}}, {"name": {"$match": "S_CreateReleaseBundle_6237_002.txt"}}]})'
+      addedProperties:
+        myRunNumber: ${run_id}
+
+  - name: S_CreateReleaseBundle_6237_002_ReleaseBundle
+    type: ReleaseBundle
+    configuration:
+      sourceDistribution: s_distribution
+      name: name
+      version: '1'
+
+pipelines:
+  - name: pipeline_S_CreateReleaseBundle_6237_002
+    steps:
+      - name: S_CreateReleaseBundle_6237_002_1
+        type: Bash
+        configuration:
+          integrations:
+            - name: s_artifactory
+          outputResources:
+            - name: S_CreateReleaseBundle_6237_002_Aql
+        execution:
+          onExecute:
+            - echo "${run_id}" > S_CreateReleaseBundle_6237_002.txt
+            - jfrog rt upload S_CreateReleaseBundle_6237_002.txt test-automation-generic-local --insecure-tls=$no_verify_ssl
+
+      - name: S_CreateReleaseBundle_6237_002_2
+        type: CreateReleaseBundle
+        configuration:
+          releaseBundleName: ${JFROG_CLI_BUILD_NAME}
+          releaseBundleVersion: ${run_id}
+          dryRun: false
+          inputResources:
+            - name: S_CreateReleaseBundle_6237_002_Aql
+          outputResources:
+            - name: S_CreateReleaseBundle_6237_002_ReleaseBundle
+
+      - name: S_CreateReleaseBundle_6237_002_3
+        type: Bash
+        configuration:
+          inputResources:
+            - name: S_CreateReleaseBundle_6237_002_ReleaseBundle
+          integrations:
+            - name: s_artifactory
+            - name: s_distribution
+        execution:
+          onExecute:
+            - releaseBundleName=$(find_resource_variable S_CreateReleaseBundle_6237_002_ReleaseBundle name)
+            - releaseBundleVersion=$(find_resource_variable S_CreateReleaseBundle_6237_002_ReleaseBundle version)
+            - curlOptions="--silent --retry 3 -w %{http_code} -u $int_s_distribution_user:$int_s_distribution_apikey"
+            - if [ "$no_verify_ssl" == "true" ]; then curlOptions+=" --insecure"; fi
+            - "curl $curlOptions -H 'Content-Type: application/json' -XGET \"$int_s_distribution_url/api/v1/release_bundle/$releaseBundleName/$releaseBundleVersion\" --output $step_tmp_dir/response"
+            - echo "Deleting release bundle..."
+            - jfrog config add distribution --overwrite --insecure-tls=$no_verify_ssl --dist-url $int_s_distribution_url --user $int_s_distribution_user --apikey $int_s_distribution_apikey --interactive=false
+            - jfrog config use distribution
+            - jfrog rt release-bundle-delete --delete-from-dist=true --insecure-tls=$no_verify_ssl $releaseBundleName $releaseBundleVersion
+            - jfrog config remove distribution
+            - echo "Checking resources..."
+            - myRunNumber=$(cat $step_tmp_dir/response | jq -r '.artifacts[0].props[] | select(.key == "myRunNumber") | .values[0]')
+            - if [ "$myRunNumber" != "${run_id}" ]; then return 1; fi
+            - if [ "$res_S_CreateReleaseBundle_6237_002_ReleaseBundle_name" != "${JFROG_CLI_BUILD_NAME}" ]; then return 1; fi
+            - if [ "$res_S_CreateReleaseBundle_6237_002_ReleaseBundle_version" != "${run_id}" ]; then return 1; fi
+            - if [ "$res_S_CreateReleaseBundle_6237_002_ReleaseBundle_isSigned" == "true" ]; then return 1; fi

--- a/tests/yaml/S_CreateReleaseBundle_6237_003.yml
+++ b/tests/yaml/S_CreateReleaseBundle_6237_003.yml
@@ -1,0 +1,74 @@
+resources:
+  - name: S_CreateReleaseBundle_6237_003_Aql
+    type: Aql
+    configuration:
+      sourceArtifactory: s_artifactory
+      query: 'items.find({"$and": [{"repo": {"$eq": "test-automation-generic-local"}}, {"name": {"$match": "S_CreateReleaseBundle_6237_003.txt"}}]})'
+      mappings:
+        - name: myMapping
+          input: test-automation-generic-local/S_CreateReleaseBundle_6237_003.txt
+          output: test-automation-generic-local/S_CreateReleaseBundle_6237_003_2.txt
+
+  - name: S_CreateReleaseBundle_6237_003_ReleaseBundle
+    type: ReleaseBundle
+    configuration:
+      sourceDistribution: s_distribution
+      name: name
+      version: '1'
+
+pipelines:
+  - name: pipeline_S_CreateReleaseBundle_6237_003
+    steps:
+      - name: S_CreateReleaseBundle_6237_003_1
+        type: Bash
+        configuration:
+          integrations:
+            - name: s_artifactory
+          outputResources:
+            - name: S_CreateReleaseBundle_6237_003_Aql
+        execution:
+          onExecute:
+            - echo "${run_id}" > S_CreateReleaseBundle_6237_003.txt
+            - jfrog rt upload S_CreateReleaseBundle_6237_003.txt test-automation-generic-local --insecure-tls=$no_verify_ssl
+
+      - name: S_CreateReleaseBundle_6237_003_2
+        type: CreateReleaseBundle
+        configuration:
+          releaseBundleName: ${JFROG_CLI_BUILD_NAME}
+          releaseBundleVersion: ${run_id}
+          dryRun: false
+          inputResources:
+            - name: S_CreateReleaseBundle_6237_003_Aql
+          outputResources:
+            - name: S_CreateReleaseBundle_6237_003_ReleaseBundle
+
+      - name: S_CreateReleaseBundle_6237_003_3
+        type: Bash
+        configuration:
+          inputResources:
+            - name: S_CreateReleaseBundle_6237_003_ReleaseBundle
+          integrations:
+            - name: s_artifactory
+            - name: s_distribution
+        execution:
+          onExecute:
+            - releaseBundleName=$(find_resource_variable S_CreateReleaseBundle_6237_003_ReleaseBundle name)
+            - releaseBundleVersion=$(find_resource_variable S_CreateReleaseBundle_6237_003_ReleaseBundle version)
+            - curlOptions="--silent --retry 3 -w %{http_code} -u $int_s_distribution_user:$int_s_distribution_apikey"
+            - if [ "$no_verify_ssl" == "true" ]; then curlOptions+=" --insecure"; fi
+            - "curl $curlOptions -H 'Content-Type: application/json' -XGET \"$int_s_distribution_url/api/v1/release_bundle/$releaseBundleName/$releaseBundleVersion\" --output $step_tmp_dir/response"
+            - echo "Deleting release bundle..."
+            - jfrog config add distribution --overwrite --insecure-tls=$no_verify_ssl --dist-url $int_s_distribution_url --user $int_s_distribution_user --apikey $int_s_distribution_apikey --interactive=false
+            - jfrog config use distribution
+            - jfrog rt release-bundle-delete --delete-from-dist=true --insecure-tls=$no_verify_ssl $releaseBundleName $releaseBundleVersion
+            - jfrog config remove distribution
+            - echo "Checking resources..."
+            - artifact=$(cat $step_tmp_dir/response | jq '.artifacts[0]')
+            - echo "$artifact"
+            - sourceRepoPath=$(echo "$artifact" | jq -r '.sourceRepoPath')
+            - targetRepoPath=$(echo "$artifact" | jq -r '.targetRepoPath')
+            - if [ "$sourceRepoPath" != "test-automation-generic-local/S_CreateReleaseBundle_6237_003.txt" ]; then return 1; fi
+            - if [ "$targetRepoPath" != "test-automation-generic-local/S_CreateReleaseBundle_6237_003_2.txt" ]; then return 1; fi
+            - if [ "$res_S_CreateReleaseBundle_6237_003_ReleaseBundle_name" != "${JFROG_CLI_BUILD_NAME}" ]; then return 1; fi
+            - if [ "$res_S_CreateReleaseBundle_6237_003_ReleaseBundle_version" != "${run_id}" ]; then return 1; fi
+            - if [ "$res_S_CreateReleaseBundle_6237_003_ReleaseBundle_isSigned" == "true" ]; then return 1; fi

--- a/tests/yaml/S_CreateReleaseBundle_6237_004.yml
+++ b/tests/yaml/S_CreateReleaseBundle_6237_004.yml
@@ -1,0 +1,72 @@
+resources:
+  - name: S_CreateReleaseBundle_6237_004_Aql
+    type: Aql
+    configuration:
+      sourceArtifactory: s_artifactory
+      query: 'items.find({"$and": [{"repo": {"$eq": "test-automation-generic-local"}}, {"name": {"$match": "S_CreateReleaseBundle_6237_004.txt"}}]})'
+      mappings:
+        - name: myMapping
+          input: test-automation-generic-local/S_CreateReleaseBundle_6237_004.(.*)
+          output: test-automation-generic-local/S_CreateReleaseBundle_6237_004_1.$1
+
+  - name: S_CreateReleaseBundle_6237_004_ReleaseBundle
+    type: ReleaseBundle
+    configuration:
+      sourceDistribution: s_distribution
+      name: name
+      version: '1'
+
+pipelines:
+  - name: pipeline_S_CreateReleaseBundle_6237_004
+    steps:
+      - name: S_CreateReleaseBundle_6237_004_1
+        type: Bash
+        configuration:
+          integrations:
+            - name: s_artifactory
+          outputResources:
+            - name: S_CreateReleaseBundle_6237_004_Aql
+        execution:
+          onExecute:
+            - echo "${run_id}" > S_CreateReleaseBundle_6237_004.txt
+            - jfrog rt upload S_CreateReleaseBundle_6237_004.txt test-automation-generic-local --insecure-tls=$no_verify_ssl
+
+      - name: S_CreateReleaseBundle_6237_004_2
+        type: CreateReleaseBundle
+        configuration:
+          releaseBundleName: ${JFROG_CLI_BUILD_NAME}
+          releaseBundleVersion: ${run_id}
+          dryRun: false
+          inputResources:
+            - name: S_CreateReleaseBundle_6237_004_Aql
+          outputResources:
+            - name: S_CreateReleaseBundle_6237_004_ReleaseBundle
+
+
+      - name: S_CreateReleaseBundle_6237_004_3
+        type: Bash
+        configuration:
+          inputResources:
+            - name: S_CreateReleaseBundle_6237_004_ReleaseBundle
+          integrations:
+            - name: s_artifactory
+            - name: s_distribution
+        execution:
+          onExecute:
+            - releaseBundleName=$(find_resource_variable S_CreateReleaseBundle_6237_004_ReleaseBundle name)
+            - releaseBundleVersion=$(find_resource_variable S_CreateReleaseBundle_6237_004_ReleaseBundle version)
+            - curlOptions="--silent --retry 3 -w %{http_code} -u $int_s_distribution_user:$int_s_distribution_apikey"
+            - if [ "$no_verify_ssl" == "true" ]; then curlOptions+=" --insecure"; fi
+            - "curl $curlOptions -H 'Content-Type: application/json' -XGET \"$int_s_distribution_url/api/v1/release_bundle/$releaseBundleName/$releaseBundleVersion\" --output $step_tmp_dir/response"
+            - echo "Deleting release bundle..."
+            - jfrog config add distribution --overwrite --insecure-tls=$no_verify_ssl --dist-url $int_s_distribution_url --user $int_s_distribution_user --apikey $int_s_distribution_apikey --interactive=false
+            - jfrog config use distribution
+            - jfrog rt release-bundle-delete --delete-from-dist=true --insecure-tls=$no_verify_ssl $releaseBundleName $releaseBundleVersion
+            - jfrog config remove distribution
+            - echo "Checking resources..."
+            - mappedArtifact=$(cat $step_tmp_dir/response | jq '.artifacts[] | select(.sourceRepoPath == "test-automation-generic-local/S_CreateReleaseBundle_6237_004.txt")')
+            - echo "$mappedArtifact"
+            - sourceRepoPath=$(echo "$mappedArtifact" | jq -r '.sourceRepoPath')
+            - targetRepoPath=$(echo "$mappedArtifact" | jq -r '.targetRepoPath')
+            - if [ "$sourceRepoPath" != "test-automation-generic-local/S_CreateReleaseBundle_6237_004.txt" ]; then return 1; fi
+            - if [ "$targetRepoPath" != "test-automation-generic-local/S_CreateReleaseBundle_6237_004_1.txt" ]; then return 1; fi

--- a/tests/yaml/S_CreateReleaseBundle_6237_005.yml
+++ b/tests/yaml/S_CreateReleaseBundle_6237_005.yml
@@ -1,0 +1,64 @@
+resources:
+  - name: S_CreateReleaseBundle_6237_005_Aql
+    type: Aql
+    configuration:
+      sourceArtifactory: s_artifactory
+      query: 'items.find({"$and": [{"repo": {"$eq": "test-automation-generic-local"}}, {"name": {"$match": "S_CreateReleaseBundle_6237_005.txt"}}]})'
+
+  - name: S_CreateReleaseBundle_6237_005_ReleaseBundle
+    type: ReleaseBundle
+    configuration:
+      sourceDistribution: s_distribution
+      name: name
+      version: '1'
+
+pipelines:
+  - name: pipeline_S_CreateReleaseBundle_6237_005
+    steps:
+      - name: S_CreateReleaseBundle_6237_005_1
+        type: Bash
+        configuration:
+          integrations:
+            - name: s_artifactory
+          outputResources:
+            - name: S_CreateReleaseBundle_6237_005_Aql
+        execution:
+          onExecute:
+            - echo "${run_id}" > S_CreateReleaseBundle_6237_005.txt
+            - jfrog rt upload S_CreateReleaseBundle_6237_005.txt test-automation-generic-local --insecure-tls=$no_verify_ssl
+
+      - name: S_CreateReleaseBundle_6237_005_2
+        type: CreateReleaseBundle
+        configuration:
+          releaseBundleName: ${JFROG_CLI_BUILD_NAME}
+          releaseBundleVersion: ${run_id}
+          dryRun: false
+          description: "My release description"
+          inputResources:
+            - name: S_CreateReleaseBundle_6237_005_Aql
+          outputResources:
+            - name: S_CreateReleaseBundle_6237_005_ReleaseBundle
+
+      - name: S_CreateReleaseBundle_6237_005_3
+        type: Bash
+        configuration:
+          inputResources:
+            - name: S_CreateReleaseBundle_6237_005_ReleaseBundle
+          integrations:
+            - name: s_artifactory
+            - name: s_distribution
+        execution:
+          onExecute:
+            - releaseBundleName=$(find_resource_variable S_CreateReleaseBundle_6237_005_ReleaseBundle name)
+            - releaseBundleVersion=$(find_resource_variable S_CreateReleaseBundle_6237_005_ReleaseBundle version)
+            - curlOptions="--silent --retry 3 -w %{http_code} -u $int_s_distribution_user:$int_s_distribution_apikey"
+            - if [ "$no_verify_ssl" == "true" ]; then curlOptions+=" --insecure"; fi
+            - "curl $curlOptions -H 'Content-Type: application/json' -XGET \"$int_s_distribution_url/api/v1/release_bundle/$releaseBundleName/$releaseBundleVersion\" --output $step_tmp_dir/response"
+            - echo "Deleting release bundle..."
+            - jfrog config add distribution --overwrite --insecure-tls=$no_verify_ssl --dist-url $int_s_distribution_url --user $int_s_distribution_user --apikey $int_s_distribution_apikey --interactive=false
+            - jfrog config use distribution
+            - jfrog rt release-bundle-delete --delete-from-dist=true --insecure-tls=$no_verify_ssl $releaseBundleName $releaseBundleVersion
+            - jfrog config remove distribution
+            - echo "Checking resources..."
+            - description=$(cat $step_tmp_dir/response | jq -r '.description')
+            - if [ "$description" != "My release description" ]; then return 1; fi

--- a/tests/yaml/S_CreateReleaseBundle_6237_006.yml
+++ b/tests/yaml/S_CreateReleaseBundle_6237_006.yml
@@ -1,0 +1,70 @@
+resources:
+  - name: S_CreateReleaseBundle_6237_006_Aql
+    type: Aql
+    configuration:
+      sourceArtifactory: s_artifactory
+      query: 'items.find({"$and": [{"repo": {"$eq": "test-automation-generic-local"}}, {"name": {"$match": "S_CreateReleaseBundle_6237_006.txt"}}]})'
+
+  - name: S_CreateReleaseBundle_6237_006_ReleaseBundle
+    type: ReleaseBundle
+    configuration:
+      sourceDistribution: s_distribution
+      name: name
+      version: '1'
+
+pipelines:
+  - name: pipeline_S_CreateReleaseBundle_6237_006
+    steps:
+      - name: S_CreateReleaseBundle_6237_006_1
+        type: Bash
+        configuration:
+          integrations:
+            - name: s_artifactory
+          outputResources:
+            - name: S_CreateReleaseBundle_6237_006_Aql
+        execution:
+          onExecute:
+            - echo "${run_id}" > S_CreateReleaseBundle_6237_006.txt
+            - jfrog rt upload S_CreateReleaseBundle_6237_006.txt test-automation-generic-local --insecure-tls=$no_verify_ssl
+
+      - name: S_CreateReleaseBundle_6237_006_2
+        type: CreateReleaseBundle
+        configuration:
+          releaseBundleName: ${JFROG_CLI_BUILD_NAME}
+          releaseBundleVersion: ${run_id}
+          dryRun: false
+          releaseNotes:
+            syntax: markdown
+            content: "My *Release Notes*"
+          inputResources:
+            - name: S_CreateReleaseBundle_6237_006_Aql
+          outputResources:
+            - name: S_CreateReleaseBundle_6237_006_ReleaseBundle
+
+      - name: S_CreateReleaseBundle_6237_006_3
+        type: Bash
+        configuration:
+          inputResources:
+            - name: S_CreateReleaseBundle_6237_006_ReleaseBundle
+          integrations:
+            - name: s_artifactory
+            - name: s_distribution
+        execution:
+          onExecute:
+            - releaseBundleName=$(find_resource_variable S_CreateReleaseBundle_6237_006_ReleaseBundle name)
+            - releaseBundleVersion=$(find_resource_variable S_CreateReleaseBundle_6237_006_ReleaseBundle version)
+            - curlOptions="--silent --retry 3 -w %{http_code} -u $int_s_distribution_user:$int_s_distribution_apikey"
+            - if [ "$no_verify_ssl" == "true" ]; then curlOptions+=" --insecure"; fi
+            - "curl $curlOptions -H 'Content-Type: application/json' -XGET \"$int_s_distribution_url/api/v1/release_bundle/$releaseBundleName/$releaseBundleVersion\" --output $step_tmp_dir/response"
+            - echo "Deleting release bundle..."
+            - jfrog config add distribution --overwrite --insecure-tls=$no_verify_ssl --dist-url $int_s_distribution_url --user $int_s_distribution_user --apikey $int_s_distribution_apikey --interactive=false
+            - jfrog config use distribution
+            - jfrog rt release-bundle-delete --delete-from-dist=true --insecure-tls=$no_verify_ssl $releaseBundleName $releaseBundleVersion
+            - jfrog config remove distribution
+            - echo "Checking resources..."
+            - releaseNotes=$(cat $step_tmp_dir/response | jq '.release_notes')
+            - echo "$releaseNotes"
+            - syntax=$(echo "$releaseNotes" | jq -r '.syntax')
+            - content=$(echo "$releaseNotes" | jq -r '.content')
+            - if [ "$syntax" != "markdown" ]; then return 1; fi
+            - if [ "$content" != 'My *Release Notes*' ]; then return 1; fi

--- a/tests/yaml/S_CreateReleaseBundle_6237_007.yml
+++ b/tests/yaml/S_CreateReleaseBundle_6237_007.yml
@@ -1,0 +1,73 @@
+resources:
+  - name: S_CreateReleaseBundle_6237_007_BuildInfo
+    type: BuildInfo
+    configuration:
+      sourceArtifactory: s_artifactory
+      buildName: 'name'
+      buildNumber: '1'
+
+  - name: S_CreateReleaseBundle_6237_007_ReleaseBundle
+    type: ReleaseBundle
+    configuration:
+      sourceDistribution: s_distribution
+      name: name
+      version: '1'
+
+pipelines:
+  - name: pipeline_S_CreateReleaseBundle_6237_007
+    configuration:
+      environmentVariables:
+        readOnly:
+          JFROG_CLI_BUILD_NUMBER: "${run_id}"
+    steps:
+      - name: S_CreateReleaseBundle_6237_007_1
+        type: Bash
+        configuration:
+          integrations:
+            - name: s_artifactory
+          outputResources:
+            - name: S_CreateReleaseBundle_6237_007_BuildInfo
+        execution:
+          onExecute:
+            - echo "${run_id}" > S_CreateReleaseBundle_6237_007.txt
+            - jfrog rt upload S_CreateReleaseBundle_6237_007.txt test-automation-generic-local --insecure-tls=$no_verify_ssl
+            - jfrog rt build-publish ${JFROG_CLI_BUILD_NAME} ${JFROG_CLI_BUILD_NUMBER} --insecure-tls=$no_verify_ssl
+            - write_output S_CreateReleaseBundle_6237_007_BuildInfo buildName=${JFROG_CLI_BUILD_NAME} buildNumber=${JFROG_CLI_BUILD_NUMBER}
+
+      - name: S_CreateReleaseBundle_6237_007_2
+        type: CreateReleaseBundle
+        configuration:
+          releaseBundleName: ${JFROG_CLI_BUILD_NAME}
+          releaseBundleVersion: ${run_id}
+          dryRun: false
+          inputResources:
+            - name: S_CreateReleaseBundle_6237_007_BuildInfo
+          outputResources:
+            - name: S_CreateReleaseBundle_6237_007_ReleaseBundle
+
+      - name: S_CreateReleaseBundle_6237_007_3
+        type: Bash
+        configuration:
+          inputResources:
+            - name: S_CreateReleaseBundle_6237_007_ReleaseBundle
+          integrations:
+            - name: s_artifactory
+            - name: s_distribution
+        execution:
+          onExecute:
+            - releaseBundleName=$(find_resource_variable S_CreateReleaseBundle_6237_007_ReleaseBundle name)
+            - releaseBundleVersion=$(find_resource_variable S_CreateReleaseBundle_6237_007_ReleaseBundle version)
+            - curlOptions="--silent --retry 3 -w %{http_code} -u $int_s_distribution_user:$int_s_distribution_apikey"
+            - if [ "$no_verify_ssl" == "true" ]; then curlOptions+=" --insecure"; fi
+            - "curl $curlOptions -H 'Content-Type: application/json' -XGET \"$int_s_distribution_url/api/v1/release_bundle/$releaseBundleName/$releaseBundleVersion\" --output $step_tmp_dir/response"
+            - echo "Deleting release bundle..."
+            - jfrog config add distribution --overwrite --insecure-tls=$no_verify_ssl --dist-url $int_s_distribution_url --user $int_s_distribution_user --apikey $int_s_distribution_apikey --interactive=false
+            - jfrog config use distribution
+            - jfrog rt release-bundle-delete --delete-from-dist=true --insecure-tls=$no_verify_ssl $releaseBundleName $releaseBundleVersion
+            - jfrog config remove distribution
+            - echo "Checking resources..."
+            - if [ "$(cat $step_tmp_dir/response | jq '.artifacts | length')" != "1" ]; then return 1; fi
+            - artifact=$(cat $step_tmp_dir/response | jq '.artifacts[0]')
+            - echo "$artifact"
+            - sourceRepoPath=$(echo "$artifact" | jq -r '.sourceRepoPath')
+            - if [ "$sourceRepoPath" != "test-automation-generic-local/S_CreateReleaseBundle_6237_007.txt" ]; then return 1; fi

--- a/tests/yaml/S_CreateReleaseBundle_6237_008.yml
+++ b/tests/yaml/S_CreateReleaseBundle_6237_008.yml
@@ -1,0 +1,99 @@
+resources:
+  - name: S_CreateReleaseBundle_6237_008_BuildInfo_1
+    type: BuildInfo
+    configuration:
+      sourceArtifactory: s_artifactory
+      buildName: 'name'
+      buildNumber: '1'
+
+  - name: S_CreateReleaseBundle_6237_008_BuildInfo_2
+    type: BuildInfo
+    configuration:
+      sourceArtifactory: s_artifactory
+      buildName: 'name'
+      buildNumber: '1'
+
+  - name: S_CreateReleaseBundle_6237_008_ReleaseBundle
+    type: ReleaseBundle
+    configuration:
+      sourceDistribution: s_distribution
+      name: name
+      version: '1'
+
+pipelines:
+  - name: pipeline_S_CreateReleaseBundle_6237_008
+    configuration:
+      environmentVariables:
+        readOnly:
+          JFROG_CLI_BUILD_NUMBER: "${run_id}"
+    steps:
+      - name: S_CreateReleaseBundle_6237_008_1
+        type: Bash
+        configuration:
+          integrations:
+            - name: s_artifactory
+          outputResources:
+            - name: S_CreateReleaseBundle_6237_008_BuildInfo_1
+        execution:
+          onExecute:
+            - export JFROG_CLI_BUILD_NAME="S_CreateReleaseBundle_6237_008_1"
+            - echo "${run_id}" > S_CreateReleaseBundle_6237_008_1.txt
+            - jfrog rt upload S_CreateReleaseBundle_6237_008_1.txt test-automation-generic-local --insecure-tls=$no_verify_ssl
+            - jfrog rt build-publish ${JFROG_CLI_BUILD_NAME} ${JFROG_CLI_BUILD_NUMBER} --insecure-tls=$no_verify_ssl
+            - write_output S_CreateReleaseBundle_6237_008_BuildInfo_1 buildName=${JFROG_CLI_BUILD_NAME} buildNumber=${JFROG_CLI_BUILD_NUMBER}
+
+      - name: S_CreateReleaseBundle_6237_008_2
+        type: Bash
+        configuration:
+          integrations:
+            - name: s_artifactory
+          inputSteps:
+            - name: S_CreateReleaseBundle_6237_008_1
+          outputResources:
+            - name: S_CreateReleaseBundle_6237_008_BuildInfo_2
+        execution:
+          onExecute:
+            - export JFROG_CLI_BUILD_NAME="S_CreateReleaseBundle_6237_008_2"
+            - echo "${run_id}" > S_CreateReleaseBundle_6237_008_2.txt
+            - jfrog rt upload S_CreateReleaseBundle_6237_008_2.txt test-automation-generic-local --insecure-tls=$no_verify_ssl
+            - jfrog rt build-publish ${JFROG_CLI_BUILD_NAME} ${JFROG_CLI_BUILD_NUMBER} --insecure-tls=$no_verify_ssl
+            - write_output S_CreateReleaseBundle_6237_008_BuildInfo_2 buildName=${JFROG_CLI_BUILD_NAME} buildNumber=${JFROG_CLI_BUILD_NUMBER}
+
+      - name: S_CreateReleaseBundle_6237_008_3
+        type: CreateReleaseBundle
+        configuration:
+          releaseBundleName: ${JFROG_CLI_BUILD_NAME}
+          releaseBundleVersion: ${run_id}
+          dryRun: false
+          inputResources:
+            - name: S_CreateReleaseBundle_6237_008_BuildInfo_1
+            - name: S_CreateReleaseBundle_6237_008_BuildInfo_2
+          outputResources:
+            - name: S_CreateReleaseBundle_6237_008_ReleaseBundle
+
+      - name: S_CreateReleaseBundle_6237_008_4
+        type: Bash
+        configuration:
+          inputResources:
+            - name: S_CreateReleaseBundle_6237_008_ReleaseBundle
+          integrations:
+            - name: s_artifactory
+            - name: s_distribution
+        execution:
+          onExecute:
+            - releaseBundleName=$(find_resource_variable S_CreateReleaseBundle_6237_008_ReleaseBundle name)
+            - releaseBundleVersion=$(find_resource_variable S_CreateReleaseBundle_6237_008_ReleaseBundle version)
+            - curlOptions="--silent --retry 3 -w %{http_code} -u $int_s_distribution_user:$int_s_distribution_apikey"
+            - if [ "$no_verify_ssl" == "true" ]; then curlOptions+=" --insecure"; fi
+            - "curl $curlOptions -H 'Content-Type: application/json' -XGET \"$int_s_distribution_url/api/v1/release_bundle/$releaseBundleName/$releaseBundleVersion\" --output $step_tmp_dir/response"
+            - echo "Deleting release bundle..."
+            - jfrog config add distribution --overwrite --insecure-tls=$no_verify_ssl --dist-url $int_s_distribution_url --user $int_s_distribution_user --apikey $int_s_distribution_apikey --interactive=false
+            - jfrog config use distribution
+            - jfrog rt release-bundle-delete --delete-from-dist=true --insecure-tls=$no_verify_ssl $releaseBundleName $releaseBundleVersion
+            - jfrog config remove distribution
+            - echo "Checking resources..."
+            - if [ "$(cat $step_tmp_dir/response | jq '.artifacts | length')" != "2" ]; then return 1; fi
+            - artifactOne=$(cat $step_tmp_dir/response | jq '.artifacts[] | select(.sourceRepoPath == "test-automation-generic-local/S_CreateReleaseBundle_6237_008_1.txt")')
+            - artifactTwo=$(cat $step_tmp_dir/response | jq '.artifacts[] | select(.sourceRepoPath == "test-automation-generic-local/S_CreateReleaseBundle_6237_008_2.txt")')
+            - if [ "$(echo "$artifactOne" | jq -r '.sourceRepoPath')" != "test-automation-generic-local/S_CreateReleaseBundle_6237_008_1.txt" ]; then return 1; fi
+            - if [ "$(echo "$artifactTwo" | jq -r '.sourceRepoPath')" != "test-automation-generic-local/S_CreateReleaseBundle_6237_008_2.txt" ]; then return 1; fi

--- a/tests/yaml/S_CreateReleaseBundle_6237_009.yml
+++ b/tests/yaml/S_CreateReleaseBundle_6237_009.yml
@@ -1,0 +1,71 @@
+resources:
+  - name: S_CreateReleaseBundle_6237_009_BuildInfo
+    type: BuildInfo
+    configuration:
+      sourceArtifactory: s_artifactory
+      buildName: 'name'
+      buildNumber: '1'
+
+  - name: S_CreateReleaseBundle_6237_009_ReleaseBundle
+    type: ReleaseBundle
+    configuration:
+      sourceDistribution: s_distribution
+      name: name
+      version: '1'
+
+pipelines:
+  - name: pipeline_S_CreateReleaseBundle_6237_009
+    configuration:
+      environmentVariables:
+        readOnly:
+          JFROG_CLI_BUILD_NUMBER: "${run_id}"
+    steps:
+      - name: S_CreateReleaseBundle_6237_009_1
+        type: Bash
+        configuration:
+          integrations:
+            - name: s_artifactory
+          outputResources:
+            - name: S_CreateReleaseBundle_6237_009_BuildInfo
+        execution:
+          onExecute:
+            - echo "${run_id}" > S_CreateReleaseBundle_6237_009.txt
+            - jfrog rt upload S_CreateReleaseBundle_6237_009.txt test-automation-generic-local --insecure-tls=$no_verify_ssl
+            - jfrog rt build-publish ${JFROG_CLI_BUILD_NAME} ${JFROG_CLI_BUILD_NUMBER} --insecure-tls=$no_verify_ssl
+            - write_output S_CreateReleaseBundle_6237_009_BuildInfo buildName=${JFROG_CLI_BUILD_NAME} buildNumber=${JFROG_CLI_BUILD_NUMBER}
+
+      - name: S_CreateReleaseBundle_6237_009_2
+        type: CreateReleaseBundle
+        configuration:
+          releaseBundleName: ${JFROG_CLI_BUILD_NAME}
+          releaseBundleVersion: ${run_id}
+          dryRun: false
+          description: "My release description"
+          inputResources:
+            - name: S_CreateReleaseBundle_6237_009_BuildInfo
+          outputResources:
+            - name: S_CreateReleaseBundle_6237_009_ReleaseBundle
+
+      - name: S_CreateReleaseBundle_6237_009_3
+        type: Bash
+        configuration:
+          inputResources:
+            - name: S_CreateReleaseBundle_6237_009_ReleaseBundle
+          integrations:
+            - name: s_artifactory
+            - name: s_distribution
+        execution:
+          onExecute:
+            - releaseBundleName=$(find_resource_variable S_CreateReleaseBundle_6237_009_ReleaseBundle name)
+            - releaseBundleVersion=$(find_resource_variable S_CreateReleaseBundle_6237_009_ReleaseBundle version)
+            - curlOptions="--silent --retry 3 -w %{http_code} -u $int_s_distribution_user:$int_s_distribution_apikey"
+            - if [ "$no_verify_ssl" == "true" ]; then curlOptions+=" --insecure"; fi
+            - "curl $curlOptions -H 'Content-Type: application/json' -XGET \"$int_s_distribution_url/api/v1/release_bundle/$releaseBundleName/$releaseBundleVersion\" --output $step_tmp_dir/response"
+            - echo "Deleting release bundle..."
+            - jfrog config add distribution --overwrite --insecure-tls=$no_verify_ssl --dist-url $int_s_distribution_url --user $int_s_distribution_user --apikey $int_s_distribution_apikey --interactive=false
+            - jfrog config use distribution
+            - jfrog rt release-bundle-delete --delete-from-dist=true --insecure-tls=$no_verify_ssl $releaseBundleName $releaseBundleVersion
+            - jfrog config remove distribution
+            - echo "Checking resources..."
+            - description=$(cat $step_tmp_dir/response | jq -r '.description')
+            - if [ "$description" != "My release description" ]; then return 1; fi

--- a/tests/yaml/S_CreateReleaseBundle_6237_010.yml
+++ b/tests/yaml/S_CreateReleaseBundle_6237_010.yml
@@ -1,0 +1,77 @@
+resources:
+  - name: S_CreateReleaseBundle_6237_010_BuildInfo
+    type: BuildInfo
+    configuration:
+      sourceArtifactory: s_artifactory
+      buildName: 'name'
+      buildNumber: '1'
+
+  - name: S_CreateReleaseBundle_6237_010_ReleaseBundle
+    type: ReleaseBundle
+    configuration:
+      sourceDistribution: s_distribution
+      name: name
+      version: '1'
+
+pipelines:
+  - name: pipeline_S_CreateReleaseBundle_6237_010
+    configuration:
+      environmentVariables:
+        readOnly:
+          JFROG_CLI_BUILD_NUMBER: "${run_id}"
+    steps:
+      - name: S_CreateReleaseBundle_6237_010_1
+        type: Bash
+        configuration:
+          integrations:
+            - name: s_artifactory
+          outputResources:
+            - name: S_CreateReleaseBundle_6237_010_BuildInfo
+        execution:
+          onExecute:
+            - echo "${run_id}" > S_CreateReleaseBundle_6237_010.txt
+            - jfrog rt upload S_CreateReleaseBundle_6237_010.txt test-automation-generic-local --insecure-tls=$no_verify_ssl
+            - jfrog rt build-publish ${JFROG_CLI_BUILD_NAME} ${JFROG_CLI_BUILD_NUMBER} --insecure-tls=$no_verify_ssl
+            - write_output S_CreateReleaseBundle_6237_010_BuildInfo buildName=${JFROG_CLI_BUILD_NAME} buildNumber=${JFROG_CLI_BUILD_NUMBER}
+
+      - name: S_CreateReleaseBundle_6237_010_2
+        type: CreateReleaseBundle
+        configuration:
+          releaseBundleName: ${JFROG_CLI_BUILD_NAME}
+          releaseBundleVersion: ${run_id}
+          dryRun: false
+          releaseNotes:
+            syntax: markdown
+            content: "My *Release Notes*"
+          inputResources:
+            - name: S_CreateReleaseBundle_6237_010_BuildInfo
+          outputResources:
+            - name: S_CreateReleaseBundle_6237_010_ReleaseBundle
+
+      - name: S_CreateReleaseBundle_6237_010_3
+        type: Bash
+        configuration:
+          inputResources:
+            - name: S_CreateReleaseBundle_6237_010_ReleaseBundle
+          integrations:
+            - name: s_artifactory
+            - name: s_distribution
+        execution:
+          onExecute:
+            - releaseBundleName=$(find_resource_variable S_CreateReleaseBundle_6237_010_ReleaseBundle name)
+            - releaseBundleVersion=$(find_resource_variable S_CreateReleaseBundle_6237_010_ReleaseBundle version)
+            - curlOptions="--silent --retry 3 -w %{http_code} -u $int_s_distribution_user:$int_s_distribution_apikey"
+            - if [ "$no_verify_ssl" == "true" ]; then curlOptions+=" --insecure"; fi
+            - "curl $curlOptions -H 'Content-Type: application/json' -XGET \"$int_s_distribution_url/api/v1/release_bundle/$releaseBundleName/$releaseBundleVersion\" --output $step_tmp_dir/response"
+            - echo "Deleting release bundle..."
+            - jfrog config add distribution --overwrite --insecure-tls=$no_verify_ssl --dist-url $int_s_distribution_url --user $int_s_distribution_user --apikey $int_s_distribution_apikey --interactive=false
+            - jfrog config use distribution
+            - jfrog rt release-bundle-delete --delete-from-dist=true --insecure-tls=$no_verify_ssl $releaseBundleName $releaseBundleVersion
+            - jfrog config remove distribution
+            - echo "Checking resources..."
+            - releaseNotes=$(cat $step_tmp_dir/response | jq '.release_notes')
+            - echo "$releaseNotes"
+            - syntax=$(echo "$releaseNotes" | jq -r '.syntax')
+            - content=$(echo "$releaseNotes" | jq -r '.content')
+            - if [ "$syntax" != "markdown" ]; then return 1; fi
+            - if [ "$content" != 'My *Release Notes*' ]; then return 1; fi

--- a/tests/yaml/S_CreateReleaseBundle_6237_011.yml
+++ b/tests/yaml/S_CreateReleaseBundle_6237_011.yml
@@ -1,0 +1,75 @@
+resources:
+  - name: S_CreateReleaseBundle_6237_011_BuildInfo
+    type: BuildInfo
+    configuration:
+      sourceArtifactory: s_artifactory
+      buildName: 'name'
+      buildNumber: '1'
+
+  - name: S_CreateReleaseBundle_6237_011_ReleaseBundle
+    type: ReleaseBundle
+    configuration:
+      sourceDistribution: s_distribution
+      name: name
+      version: '1'
+
+pipelines:
+  - name: pipeline_S_CreateReleaseBundle_6237_011
+    configuration:
+      environmentVariables:
+        readOnly:
+          JFROG_CLI_BUILD_NUMBER: "${run_id}"
+    steps:
+      - name: S_CreateReleaseBundle_6237_011_1
+        type: Bash
+        configuration:
+          integrations:
+            - name: s_artifactory
+          outputResources:
+            - name: S_CreateReleaseBundle_6237_011_BuildInfo
+        execution:
+          onExecute:
+            - echo "${run_id}" > S_CreateReleaseBundle_6237_011.txt
+            - jfrog rt upload S_CreateReleaseBundle_6237_011.txt test-automation-generic-local --insecure-tls=$no_verify_ssl
+            - jfrog rt build-publish ${JFROG_CLI_BUILD_NAME} ${JFROG_CLI_BUILD_NUMBER} --insecure-tls=$no_verify_ssl
+            - write_output S_CreateReleaseBundle_6237_011_BuildInfo buildName=${JFROG_CLI_BUILD_NAME} buildNumber=${JFROG_CLI_BUILD_NUMBER}
+
+      - name: S_CreateReleaseBundle_6237_011_2
+        type: CreateReleaseBundle
+        configuration:
+          releaseBundleName: ${JFROG_CLI_BUILD_NAME}
+          releaseBundleVersion: ${run_id}
+          dryRun: false
+          sign: true
+          inputResources:
+            - name: S_CreateReleaseBundle_6237_011_BuildInfo
+          outputResources:
+            - name: S_CreateReleaseBundle_6237_011_ReleaseBundle
+
+      - name: S_CreateReleaseBundle_6237_011_3
+        type: Bash
+        configuration:
+          inputResources:
+            - name: S_CreateReleaseBundle_6237_011_ReleaseBundle
+          integrations:
+            - name: s_artifactory
+            - name: s_distribution
+        execution:
+          onExecute:
+            - releaseBundleName=$(find_resource_variable S_CreateReleaseBundle_6237_011_ReleaseBundle name)
+            - releaseBundleVersion=$(find_resource_variable S_CreateReleaseBundle_6237_011_ReleaseBundle version)
+            - curlOptions="--silent --retry 3 -w %{http_code} -u $int_s_distribution_user:$int_s_distribution_apikey"
+            - if [ "$no_verify_ssl" == "true" ]; then curlOptions+=" --insecure"; fi
+            - "curl $curlOptions -H 'Content-Type: application/json' -XGET -L \"$int_s_distribution_url/api/v1/release_bundle/$releaseBundleName/$releaseBundleVersion\" --output $step_tmp_dir/response --dump-header $step_tmp_dir/response_header"
+            - "artifactSha=$(cat $step_tmp_dir/response_header | grep 'X-Checksum-Sha256: ' | awk '{print $2}' | tr -d '[:space:]')"
+            - artifactPath="${releaseBundleName}/${releaseBundleVersion}"
+            - "stepArtifact=$(curl -sS -H \"Authorization: apiToken $builder_api_token\" -H 'Content-Type: application/json' \"${pipelines_api_url}/stepArtifacts?artifactPath=${artifactPath}&artifactSha=${artifactSha}&artifactType=releaseBundle\")"
+            - echo $stepArtifact
+            - echo "Deleting release bundle..."
+            - jfrog config add distribution --overwrite --insecure-tls=$no_verify_ssl --dist-url $int_s_distribution_url --user $int_s_distribution_user --apikey $int_s_distribution_apikey --interactive=false
+            - jfrog config use distribution
+            - jfrog rt release-bundle-delete --delete-from-dist=true --insecure-tls=$no_verify_ssl $releaseBundleName $releaseBundleVersion
+            - jfrog config remove distribution
+            - echo "Checking resources..."
+            - stepArtifactSha=$(echo $stepArtifact | jq -r '.artifactSha')
+            - if [ "$stepArtifactSha" != "$artifactSha" ]; then return 1; fi


### PR DESCRIPTION
New test cases for Bash CreateReleaseBundle and for save_artifact_info for a releaseBundle missing name and version.  I've also updated existing Bash CreateReleaseBundle tests to use the CLI to delete the release bundle because it's less complicated.