### PR TITLE
Fix S_Bash_6237_001.

### DIFF
--- a/tests/yaml/S_Bash_6237_001.yml
+++ b/tests/yaml/S_Bash_6237_001.yml
@@ -8,4 +8,5 @@ pipelines:
             - name: s_artifactory
         execution:
           onExecute:
+            - echo "{}" > output.json
             - save_artifact_info releaseBundle output.json


### PR DESCRIPTION
`save_artifact_info` has changed since this test was written, so it would now fail earlier without a file containing an object.