### PR TITLE
PIPE-7216 fix typo where ssh dir does not get

### DIFF
--- a/tests/yaml/S_BASH_7261_0001.yml
+++ b/tests/yaml/S_BASH_7261_0001.yml
@@ -1,0 +1,27 @@
+pipelines:
+  - name: S_BASH_7261_0001
+    steps:
+      - name: S_BASH_7261_0001_1
+        type: Bash
+        configuration:
+          runtime:
+            type: host
+          affinityGroup: S_BASH_7261_0001
+        execution:
+          onExecute:
+            - echo hello
+            - rm -rf ~/.ssh || true
+      - name: S_BASH_7261_0001_2
+        type: Bash
+        configuration:
+          runtime:
+            type: host
+          affinityGroup: S_BASH_7261_0001
+          inputSteps:
+            - name: S_BASH_7261_0001_1
+          integrations:
+            - name: s_BASH_7261_SSHKEY
+        execution:
+          onExecute:
+            - ls ~/.ssh
+            - echo "noop"

--- a/tests/yaml/S_BASH_7261_0002.yml
+++ b/tests/yaml/S_BASH_7261_0002.yml
@@ -1,0 +1,35 @@
+resources:
+  - name: S_BASH_7261_0002_resource
+    type: VmCluster
+    configuration:
+      sshKey: s_BASH_7261_SSHKEY
+      targets:
+        - 0.0.0.0
+
+pipelines:
+  - name: S_BASH_7261_0002
+    steps:
+      - name: S_BASH_7261_0002_1
+        type: Bash
+        configuration:
+          runtime:
+            type: host
+          affinityGroup: S_BASH_7261_0002
+        execution:
+          onExecute:
+            - echo hello
+            - rm -rf ~/.ssh || true
+      - name: S_BASH_7261_0002_2
+        type: Bash
+        configuration:
+          runtime:
+            type: host
+          affinityGroup: S_BASH_7261_0002
+          inputSteps:
+            - name: S_BASH_7261_0002_1
+          inputResources:
+            - name: S_BASH_7261_0002_resource
+        execution:
+          onExecute:
+            - ls ~/.ssh
+            - echo "noop"


### PR DESCRIPTION
created on build nodes if it did not exist to begin with on the
buildImage. Instead of created ~/.ssh it was creating ~./ssh