### PR TITLE
Update S_PromoteBuild_0018-22 for non-SCM paths.

### DIFF
--- a/tests/yaml/S_PromoteBuild_0018.yml
+++ b/tests/yaml/S_PromoteBuild_0018.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: S_PromoteBuild_0018_GitRepo
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
       branches:
         include: master
 
@@ -55,7 +58,10 @@ pipelines:
         execution:
           onExecute:
             # create an invalid signature file
-            - export head_sig_path=$(jfrog rt s artifactory-pipe-info/pipeline_S_PromoteBuild_0018/{{gitBranch}}/*/s-S_PromoteBuild_0018_2.json.sig | jq '.[0].path')
+            - export head_sig_path=$(jfrog rt s artifactory-pipe-info/pipeline_S_PromoteBuild_0018/{{gitBranch}}/${run_number}/s-S_PromoteBuild_0018_2.json.sig | jq '.[0].path') # SCM pipeline source
+            - if [ "$head_sig_path" == "null" ]; then export head_sig_path=$(jfrog rt s artifactory-pipe-info/pipeline_S_PromoteBuild_0018/${run_number}/s-S_PromoteBuild_0018_2.json.sig | jq '.[0].path'); fi # Non-SCM pipeline source
+            - if [ "$head_sig_path" == "null" ]; then echo "s-S_PromoteBuild_0018_2.json.sig not found"; return 1; fi
+            - add_run_variables head_sig_path="${head_sig_path}"
             - execute_command "jfrog rt u $res_S_PromoteBuild_0018_GitRepo_resourcePath/tests/artifacts/invalidGPGSig $head_sig_path --quiet"
       - name: S_PromoteBuild_0018_4
         type: PromoteBuild
@@ -69,4 +75,4 @@ pipelines:
           targetRepository: test-automation-go-local
         execution:
           onComplete:
-            - execute_command "jfrog rt delete artifactory-pipe-info/pipeline_S_PromoteBuild_0018/{{gitBranch}} --quiet"
+            - execute_command "jfrog rt delete ${head_sig_path} --quiet"

--- a/tests/yaml/S_PromoteBuild_0019.yml
+++ b/tests/yaml/S_PromoteBuild_0019.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: S_PromoteBuild_0019_GitRepo
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
       branches:
         include: master
 
@@ -55,7 +58,10 @@ pipelines:
         execution:
           onExecute:
             # create an invalid signature file
-            - export head_sig_path=$(jfrog rt s artifactory-pipe-info/pipeline_S_PromoteBuild_0019/{{gitBranch}}/*/s-S_PromoteBuild_0019_2.json.sig | jq '.[0].path')
+            - export head_sig_path=$(jfrog rt s artifactory-pipe-info/pipeline_S_PromoteBuild_0019/{{gitBranch}}/${run_number}/s-S_PromoteBuild_0019_2.json.sig | jq '.[0].path') # SCM pipeline source
+            - if [ "$head_sig_path" == "null" ]; then export head_sig_path=$(jfrog rt s artifactory-pipe-info/pipeline_S_PromoteBuild_0019/${run_number}/s-S_PromoteBuild_0019_2.json.sig | jq '.[0].path'); fi # Non-SCM pipeline source
+            - if [ "$head_sig_path" == "null" ]; then echo "s-S_PromoteBuild_0019_2.json.sig not found"; return 1; fi
+            - add_run_variables head_sig_path="${head_sig_path}"
             - execute_command "jfrog rt u $res_S_PromoteBuild_0019_GitRepo_resourcePath/tests/artifacts/invalidGPGSig $head_sig_path --quiet"
       - name: S_PromoteBuild_0019_4
         type: PromoteBuild
@@ -72,4 +78,4 @@ pipelines:
           failOnValidate: true
         execution:
           onComplete:
-            - execute_command "jfrog rt delete artifactory-pipe-info/pipeline_S_PromoteBuild_0019/{{gitBranch}} --quiet"
+            - execute_command "jfrog rt delete ${head_sig_path} --quiet"

--- a/tests/yaml/S_PromoteBuild_0020.yml
+++ b/tests/yaml/S_PromoteBuild_0020.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: S_PromoteBuild_0020_GitRepo
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
       branches:
         include: master
 
@@ -56,4 +59,7 @@ pipelines:
           failOnValidate: true
         execution:
           onComplete:
-            - execute_command "jfrog rt delete artifactory-pipe-info/pipeline_S_PromoteBuild_0020/{{gitBranch}} --quiet"
+            - export head_sig_path=$(jfrog rt s artifactory-pipe-info/pipeline_S_PromoteBuild_0020/{{gitBranch}}/${run_number}/s-S_PromoteBuild_0020_2.json.sig | jq '.[0].path') # SCM pipeline source
+            - if [ "$head_sig_path" == "null" ]; then export head_sig_path=$(jfrog rt s artifactory-pipe-info/pipeline_S_PromoteBuild_0020/${run_number}/s-S_PromoteBuild_0020_2.json.sig | jq '.[0].path'); fi # Non-SCM pipeline source
+            - if [ "$head_sig_path" == "null" ]; then echo "s-S_PromoteBuild_0020_2.json.sig not found"; return 1; fi
+            - execute_command "jfrog rt delete ${head_sig_path} --quiet"

--- a/tests/yaml/S_PromoteBuild_0021.yml
+++ b/tests/yaml/S_PromoteBuild_0021.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: S_PromoteBuild_0021_GitRepo
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
       branches:
         include: master
 
@@ -55,7 +58,10 @@ pipelines:
         execution:
           onExecute:
             # create an invalid signature file
-            - export head_sig_path=$(jfrog rt s artifactory-pipe-info/pipeline_S_PromoteBuild_0021/{{gitBranch}}/*/s-S_PromoteBuild_0021_2.json.sig | jq '.[0].path')
+            - export head_sig_path=$(jfrog rt s artifactory-pipe-info/pipeline_S_PromoteBuild_0021/{{gitBranch}}/${run_number}/s-S_PromoteBuild_0021_2.json.sig | jq '.[0].path') # SCM pipeline source
+            - if [ "$head_sig_path" == "null" ]; then export head_sig_path=$(jfrog rt s artifactory-pipe-info/pipeline_S_PromoteBuild_0021/${run_number}/s-S_PromoteBuild_0021_2.json.sig | jq '.[0].path'); fi # Non-SCM pipeline source
+            - if [ "$head_sig_path" == "null" ]; then echo "s-S_PromoteBuild_0021_2.json.sig not found"; return 1; fi
+            - add_run_variables head_sig_path="${head_sig_path}"
             - execute_command "jfrog rt u $res_S_PromoteBuild_0021_GitRepo_resourcePath/tests/artifacts/invalidGPGSig $head_sig_path --quiet"
       - name: S_PromoteBuild_0021_4
         type: PromoteBuild
@@ -70,4 +76,4 @@ pipelines:
           failOnValidate: false
         execution:
           onComplete:
-            - execute_command "jfrog rt delete artifactory-pipe-info/pipeline_S_PromoteBuild_0021/{{gitBranch}} --quiet"
+            - execute_command "jfrog rt delete ${head_sig_path} --quiet"


### PR DESCRIPTION
The path is different for SCM pipeline sources and non-SCM.  And the GitRepo resource input paths were never templated, so I've updated those as well.