### PR TITLE
PIPE-6001 - New Jenkins test cases.

### DIFF
--- a/tests/yaml/S_B_Jen_0044.yml
+++ b/tests/yaml/S_B_Jen_0044.yml
@@ -4,7 +4,7 @@ pipelines:
       - name: S_B_Jen_0044_1
         type: Jenkins
         configuration:
-          timeoutSeconds: 2
+          timeoutSeconds: 60
           jenkinsJobName: testFolder/multibranch
           jenkinsBranchName: {{gitBranch}}
           buildParameters:

--- a/tests/yaml/S_B_Jen_6001_001.yml
+++ b/tests/yaml/S_B_Jen_6001_001.yml
@@ -1,0 +1,25 @@
+pipelines: # Two separate steps to configure different timeouts
+  - name: S_B_Jen_6001_001_1
+    steps:
+      - name: S_B_Jen_6001_001_1
+        type: Jenkins
+        configuration:
+          timeoutSeconds: 1200
+          priority: 900
+          jenkinsJobName: testFolder/singlebranch
+          buildParameters:
+            waitTime: 1200
+          integrations:
+            - name: S_B_Jenkins
+
+  - name: S_B_Jen_6001_001_2
+    steps:
+      - name: S_B_Jen_6001_001_2
+        type: Jenkins
+        configuration:
+          timeoutSeconds: 60
+          jenkinsJobName: testFolder/singlebranch
+          buildParameters:
+            waitTime: 600
+          integrations:
+            - name: S_B_Jenkins


### PR DESCRIPTION
A little complicated; two Jenkins steps so that the second one will be queued and not immediately start processing, and then a Bash step to make sure the first one is running or queued and a second Bash step to cancel the first Jenkins step either when we're done or to allow the second to start running.  And one timeout duration change in another test.