### PR TITLE
PIPE-9019 - Fix bug where specifying a resource

### DIFF
--- a/tests/yaml/S_Bash_9019_0001.yml
+++ b/tests/yaml/S_Bash_9019_0001.yml
@@ -1,0 +1,31 @@
+resources:
+  - name: S_Bash_9019_0001_resource_1
+    type: PropertyBag
+    configuration:
+      foo: "bar"
+
+  - name: S_Bash_9019_0001_resource_2
+    type: PropertyBag
+    configuration:
+      bar: "baz"
+
+  - name: S_Bash_9019_0001_resource_3
+    type: PropertyBag
+    configuration:
+      jfrog: "pipelines"
+
+
+pipelines:
+  - name: S_Bash_9019_0001
+    steps:
+      - name: S_Bash_9019_0001_1
+        type: Bash
+        configuration:
+          inputResources:
+            - name: S_Bash_9019_0001_resource_2
+            - name: S_Bash_9019_0001_resource_3
+          outputResources:
+            - name: S_Bash_9019_0001_resource_1
+        execution:
+          onExecute:
+            - write_output S_Bash_9019_0001_resource_1 foo=${run_id}


### PR DESCRIPTION
override in trigger pipeline caused step to error when there are
other resources for the step that are not overridden.